### PR TITLE
[Minor] add simple location broadcast for easy interface (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ intervenable_gpt2 = IntervenableModel(
 original_outputs, intervened_outputs = intervenable_gpt2(
     tokenizer("The capital of Spain is", return_tensors="pt"),
     [tokenizer("The capital of Italy is", return_tensors="pt")],
-    {"sources->base": 4)}
+    {"sources->base": 4}
 )
 original_outputs.last_hidden_state - intervened_outputs.last_hidden_state
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://nlp.stanford.edu/~wuzhengx/"><strong>Library Paper and Doc Are Forthcoming »</strong></a>
 </div>
 
-<a href="https://pypi.org/project/pyvene/"><img src="https://img.shields.io/pypi/v/pyvene?color=red"></img></a>
+<a href="https://pypi.org/project/pyvene/"><img src="https://img.shields.io/pypi/v/pyvene?color=red"></img></a> *This is a beta-release.*
 
 # **Use _Activation Intervention_ to Interpret _Causal Mechanism_ of Model**
 **pyvene** supports customizable interventions on different neural architectures (e.g., RNN or Transformers). It supports complex intervention schemas (e.g., parallel or serialized interventions) and a wide range of intervention modes (e.g., static or trained interventions) at scale to gain interpretability insights.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ intervenable_gpt2 = IntervenableModel(
             IntervenableRepresentationConfig(
                 0,            # intervening layer 0
                 "mlp_output", # intervening mlp output
-                "pos",        # intervening based on positional indices of tokens
-                1             # maximally intervening one token
             ),
         ],
         intervenable_interventions_type=VanillaIntervention

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can intervene with supported models as,
 ```python
 import pyvene
 from pyvene import IntervenableRepresentationConfig, IntervenableConfig, IntervenableModel
+from pyvene import VanillaIntervention
 
 # provided wrapper for huggingface gpt2 model
 _, tokenizer, gpt2 = pyvene.create_gpt2()
@@ -36,15 +37,16 @@ intervenable_gpt2 = IntervenableModel(
                 1             # maximally intervening one token
             ),
         ],
+        intervenable_interventions_type=VanillaIntervention
     ), 
     model = gpt2
 )
 
-# intervene base with sources on the fourth token.
+# intervene base with sources on the 4th token.
 original_outputs, intervened_outputs = intervenable_gpt2(
     tokenizer("The capital of Spain is", return_tensors="pt"),
     [tokenizer("The capital of Italy is", return_tensors="pt")],
-    {"sources->base": ([[[4]]], [[[4]]])}
+    {"sources->base": 4)}
 )
 original_outputs.last_hidden_state - intervened_outputs.last_hidden_state
 ```

--- a/pyvene/models/basic_utils.py
+++ b/pyvene/models/basic_utils.py
@@ -122,3 +122,22 @@ def top_vals(tokenizer, res, n=10):
     for i, _ in enumerate(top_values):
         tok = format_token(tokenizer, top_indices[i].item())
         print(f"{tok:<20} {top_values[i].item()}")
+
+        
+def get_list_depth(lst):
+    """Return the max depth of the input list"""
+    if isinstance(lst, list):
+        return 1 + max((list_depth(item) for item in lst), default=0)
+    return 0
+
+def get_batch_size(model_input):
+    """
+    Get batch size based on the input
+    """
+    if isinstance(model_input, torch.Tensor):
+        batch_size = model_input.shape[0]
+    else:
+        for _, v in model_input.items():
+            batch_size = v.shape[0]
+            break
+    return batch_size

--- a/pyvene/models/basic_utils.py
+++ b/pyvene/models/basic_utils.py
@@ -127,7 +127,7 @@ def top_vals(tokenizer, res, n=10):
 def get_list_depth(lst):
     """Return the max depth of the input list"""
     if isinstance(lst, list):
-        return 1 + max((list_depth(item) for item in lst), default=0)
+        return 1 + max((get_list_depth(item) for item in lst), default=0)
     return 0
 
 def get_batch_size(model_input):

--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -1084,8 +1084,10 @@ class IntervenableModel(nn.Module):
         for k, v in unit_locations.items():
             if isinstance(v, int):
                 _unit_locations[k] = ([[[v]]*batch_size], [[[v]]*batch_size])
+                self.use_fast = True
             elif isinstance(v[0], int) and isinstance(v[1], int):
                 _unit_locations[k] = ([[[v[0]]]*batch_size], [[[v[1]]]*batch_size])
+                self.use_fast = True
             elif isinstance(v[0], list) and isinstance(v[1], list):
                 pass # we don't support boardcase here yet.
             else:

--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -1074,7 +1074,27 @@ class IntervenableModel(nn.Module):
                     # for setters, we don't remove them.
                     all_set_handlers.extend(set_handlers)
         return all_set_handlers
-
+    
+    def _broadcast_unit_locations(
+        self,
+        batch_size,
+        unit_locations
+    ):
+        _unit_locations = copy.deepcopy(unit_locations)
+        for k, v in unit_locations.items():
+            if isinstance(v, int):
+                _unit_locations[k] = ([[[v]]*batch_size], [[[v]]*batch_size])
+            elif isinstance(v[0], int) and isinstance(v[1], int):
+                _unit_locations[k] = ([[[v[0]]]*batch_size], [[[v[1]]]*batch_size])
+            elif isinstance(v[0], list) and isinstance(v[1], list):
+                pass # we don't support boardcase here yet.
+            else:
+                raise ValueError(
+                    f"unit_locations {unit_locations} contains invalid format."
+                )
+                
+        return _unit_locations
+    
     def forward(
         self,
         base,
@@ -1153,7 +1173,10 @@ class IntervenableModel(nn.Module):
         # if no source inputs, we are calling a simple forward
         if sources is None and activations_sources is None:
             return self.model(**base), None
-
+        
+        unit_locations = self._broadcast_unit_locations(
+            get_batch_size(base), unit_locations)
+        
         self._input_validation(
             base,
             sources,
@@ -1258,7 +1281,10 @@ class IntervenableModel(nn.Module):
 
         if sources is None and activations_sources is None:
             return self.model.generate(inputs=base["input_ids"], **kwargs), None
-
+        
+        unit_locations = self._broadcast_unit_locations(
+            get_batch_size(base), unit_locations)
+        
         self._input_validation(
             base,
             sources,


### PR DESCRIPTION
**Descriptions:**
Adding in a simple unit location broadcast for a simpler interface.

**Testing Done:**
```
WARNING:root:Saving trainable intervention to intkey_layer.0.repr.block_output.unit.pos.nunit.1#0.bin.
WARNING:root:Saving trainable intervention to intkey_layer.1.repr.block_output.unit.pos.nunit.1#0.bin.
.Removing testing dir ./test_output_dir_prefix-cc81c6
Removing testing dir ./test_output_dir_prefix-f082ae
Removing testing dir ./test_output_dir_prefix-48fe1d
Removing testing dir ./test_output_dir_prefix-5690bf
Removing testing dir ./test_output_dir_prefix-b9ec48

----------------------------------------------------------------------
Ran 26 tests in 3.628s

OK
```