### PR TITLE
[P1] Adding in constant source intervention support with new tests

### DIFF
--- a/pyvene/models/configuration_intervenable_model.py
+++ b/pyvene/models/configuration_intervenable_model.py
@@ -13,8 +13,9 @@ IntervenableRepresentationConfig = namedtuple(
     "intervenable_layer intervenable_representation_type "
     "intervenable_unit max_number_of_units "
     "intervenable_low_rank_dimension "
-    "subspace_partition group_key intervention_link_key",
-    defaults=(0, "block_output", "pos", 1, None, None, None, None),
+    "subspace_partition group_key intervention_link_key intervenable_moe "
+    "source_representation",
+    defaults=(0, "block_output", "pos", 1, None, None, None, None, None, None),
 )
 
 

--- a/pyvene/models/interventions.py
+++ b/pyvene/models/interventions.py
@@ -40,13 +40,31 @@ class TrainableIntervention(Intervention):
 
 class ConstantSourceIntervention(Intervention):
 
-    """Intervention the original representations."""
+    """Constant source."""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.is_source_constant = True
-    
 
+
+class LocalistRepresentationIntervention(torch.nn.Module):
+
+    """Localist representation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.is_repr_distributed = False
+        
+        
+class DistributedRepresentationIntervention(torch.nn.Module):
+
+    """Distributed representation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.is_repr_distributed = True
+        
+    
 class BasisAgnosticIntervention(Intervention):
 
     """Intervention that will modify its basis in a uncontrolled manner."""
@@ -66,7 +84,7 @@ class SharedWeightsTrainableIntervention(TrainableIntervention):
         self.shared_weights = True
 
 
-class ZeroIntervention(ConstantSourceIntervention):
+class ZeroIntervention(ConstantSourceIntervention, LocalistRepresentationIntervention):
 
     """Zero-out activations."""
 
@@ -126,7 +144,7 @@ class CollectIntervention(ConstantSourceIntervention):
         return f"CollectIntervention(embed_dim={self.embed_dim})"
         
         
-class SkipIntervention(BasisAgnosticIntervention):
+class SkipIntervention(BasisAgnosticIntervention, LocalistRepresentationIntervention):
 
     """Skip the current intervening layer's computation in the hook function."""
 
@@ -156,7 +174,7 @@ class SkipIntervention(BasisAgnosticIntervention):
         return f"SkipIntervention(embed_dim={self.embed_dim})"
 
 
-class VanillaIntervention(Intervention):
+class VanillaIntervention(Intervention, LocalistRepresentationIntervention):
 
     """Intervention the original representations."""
 
@@ -191,7 +209,7 @@ class VanillaIntervention(Intervention):
         return f"VanillaIntervention(embed_dim={self.embed_dim})"
 
 
-class AdditionIntervention(BasisAgnosticIntervention):
+class AdditionIntervention(BasisAgnosticIntervention, LocalistRepresentationIntervention):
 
     """Intervention the original representations with activation addition."""
 
@@ -226,7 +244,7 @@ class AdditionIntervention(BasisAgnosticIntervention):
         return f"AdditionIntervention(embed_dim={self.embed_dim})"
 
 
-class SubtractionIntervention(BasisAgnosticIntervention):
+class SubtractionIntervention(BasisAgnosticIntervention, LocalistRepresentationIntervention):
 
     """Intervention the original representations with activation subtraction."""
 
@@ -261,7 +279,7 @@ class SubtractionIntervention(BasisAgnosticIntervention):
         return f"SubtractionIntervention(embed_dim={self.embed_dim})"
 
 
-class RotatedSpaceIntervention(TrainableIntervention):
+class RotatedSpaceIntervention(TrainableIntervention, DistributedRepresentationIntervention):
 
     """Intervention in the rotated space."""
 
@@ -299,7 +317,7 @@ class RotatedSpaceIntervention(TrainableIntervention):
         return f"RotatedSpaceIntervention(embed_dim={self.embed_dim})"
 
 
-class BoundlessRotatedSpaceIntervention(TrainableIntervention):
+class BoundlessRotatedSpaceIntervention(TrainableIntervention, DistributedRepresentationIntervention):
 
     """Intervention in the rotated space with boundary mask."""
 
@@ -366,7 +384,7 @@ class BoundlessRotatedSpaceIntervention(TrainableIntervention):
         return f"BoundlessRotatedSpaceIntervention(embed_dim={self.embed_dim})"
 
 
-class SigmoidMaskRotatedSpaceIntervention(TrainableIntervention):
+class SigmoidMaskRotatedSpaceIntervention(TrainableIntervention, DistributedRepresentationIntervention):
 
     """Intervention in the rotated space with boundary mask."""
 
@@ -420,7 +438,7 @@ class SigmoidMaskRotatedSpaceIntervention(TrainableIntervention):
         return f"SigmoidMaskRotatedSpaceIntervention(embed_dim={self.embed_dim})"
 
 
-class LowRankRotatedSpaceIntervention(TrainableIntervention):
+class LowRankRotatedSpaceIntervention(TrainableIntervention, DistributedRepresentationIntervention):
 
     """Intervention in the rotated space."""
 
@@ -503,7 +521,7 @@ class LowRankRotatedSpaceIntervention(TrainableIntervention):
         return f"LowRankRotatedSpaceIntervention(embed_dim={self.embed_dim})"
 
 
-class PCARotatedSpaceIntervention(BasisAgnosticIntervention):
+class PCARotatedSpaceIntervention(BasisAgnosticIntervention, DistributedRepresentationIntervention):
     """Intervention in the pca space."""
 
     def __init__(self, embed_dim, **kwargs):

--- a/pyvene/models/modeling_utils.py
+++ b/pyvene/models/modeling_utils.py
@@ -149,10 +149,14 @@ def get_intervenable_module_hook(model, representation) -> nn.Module:
     ]
     parameter_name = type_info[0]
     hook_type = type_info[1]
-    if "%s" in parameter_name:
+    if "%s" in parameter_name and representation.intervenable_moe is None:
         # we assume it is for the layer.
         parameter_name = parameter_name % (representation.intervenable_layer)
-
+    else:
+        parameter_name = parameter_name % (
+            int(representation.intervenable_layer), 
+            int(representation.intervenable_moe)
+        )
     module = getattr_for_torch_module(model, parameter_name)
     module_hook = getattr(module, hook_type)
 

--- a/pyvene/models/modeling_utils.py
+++ b/pyvene/models/modeling_utils.py
@@ -2,6 +2,7 @@ import torch, random
 from torch import nn
 import numpy as np
 from .intervenable_modelcard import *
+from .interventions import *
 
 
 def get_internal_model_type(model):
@@ -517,7 +518,8 @@ def do_intervention(
 
     # flatten
     original_base_shape = base_representation.shape
-    if len(original_base_shape) == 2:
+    if len(original_base_shape) == 2 or \
+        isinstance(intervention, LocalistRepresentationIntervention):
         # no pos dimension, e.g., gru
         base_representation_f = base_representation
         source_representation_f = source_representation
@@ -537,7 +539,8 @@ def do_intervention(
     )
 
     # unflatten
-    if len(original_base_shape) == 2:
+    if len(original_base_shape) == 2 or \
+        isinstance(intervention, LocalistRepresentationIntervention):
         # no pos dimension, e.g., gru
         pass
     elif len(original_base_shape) == 3:

--- a/tests/integration_tests/InterventionWithGPT2TestCase.py
+++ b/tests/integration_tests/InterventionWithGPT2TestCase.py
@@ -418,10 +418,14 @@ class InterventionWithGPT2TestCase(unittest.TestCase):
         _key = f"{intervention_layer}.{intervention_stream}"
 
         for position in positions:
-            base_activations[_key][:, position] = intervention(
-                base_activations[_key][:, position],
-                None,
-            )
+            if intervention_type == ZeroIntervention:
+                base_activations[_key][:, position] = torch.zeros_like(
+                    base_activations[_key][:, position])
+            else:
+                base_activations[_key][:, position] = intervention(
+                    base_activations[_key][:, position],
+                    None,
+                )
 
         golden_out = GPT2_RUN(
             self.gpt2, base["input_ids"], {}, {_key: base_activations[_key]}
@@ -535,7 +539,7 @@ class InterventionWithGPT2TestCase(unittest.TestCase):
                 use_base_only=True
             )
             
-    def test_with_position_intervention_constant_source_subtraction_intervention_positive(self):
+    def test_with_position_intervention_constant_source_zero_intervention_positive(self):
         """
         Enable constant source with subtraction intervention.
         """
@@ -603,6 +607,21 @@ def suite():
     suite.addTest(
         InterventionWithGPT2TestCase(
             "test_with_position_intervention_constant_source_vanilla_intervention_positive"
+        )
+    ) 
+    suite.addTest(
+        InterventionWithGPT2TestCase(
+            "test_with_position_intervention_constant_source_addition_intervention_positive"
+        )
+    ) 
+    suite.addTest(
+        InterventionWithGPT2TestCase(
+            "test_with_position_intervention_constant_source_subtraction_intervention_positive"
+        )
+    )
+    suite.addTest(
+        InterventionWithGPT2TestCase(
+            "test_with_position_intervention_constant_source_zero_intervention_positive"
         )
     ) 
     return suite

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,11 +37,7 @@ from pyvene.models.configuration_intervenable_model import (
     IntervenableConfig,
 )
 from pyvene.models.intervenable_base import IntervenableModel
-from pyvene.models.interventions import (
-    VanillaIntervention,
-    RotatedSpaceIntervention,
-    LowRankRotatedSpaceIntervention,
-)
+from pyvene.models.interventions import *
 from pyvene.models.mlp.modelings_mlp import MLPConfig
 from pyvene.models.mlp.modelings_intervenable_mlp import create_mlp_classifier
 from pyvene.models.gpt2.modelings_intervenable_gpt2 import create_gpt2_lm


### PR DESCRIPTION
**Descriptions:**
Currently, we assume source representations are provided at runtime to do the intervention. This is not easy to swap like zero-out certain representations, adding some noise to certain representations, and swapping with a static yet trainable representation which is fixed for all examples.

We add in a new type of intervention, ConstantSourceIntervention for this line of interventions.

**Testing Done:**
```
WARNING:root:Loading trainable intervention from intkey_layer.1.repr.block_output.unit.pos.nunit.1#0.bin.
.Directory './test_output_dir_prefix-d86b4d' created successfully.
.Directory './test_output_dir_prefix-4bf335' created successfully.
WARNING:root:Saving trainable intervention to intkey_layer.0.repr.block_output.unit.pos.nunit.1#0.bin.
WARNING:root:Saving trainable intervention to intkey_layer.1.repr.block_output.unit.pos.nunit.1#0.bin.
.Removing testing dir ./test_output_dir_prefix-19140d
Removing testing dir ./test_output_dir_prefix-d07d02
Removing testing dir ./test_output_dir_prefix-12751f
Removing testing dir ./test_output_dir_prefix-d86b4d
Removing testing dir ./test_output_dir_prefix-4bf335

----------------------------------------------------------------------
Ran 30 tests in 4.461s

OK

```