### PR TITLE
Model generation API simplified and cleanup tech debt on redundant variables

### DIFF
--- a/pyvene/__init__.py
+++ b/pyvene/__init__.py
@@ -37,5 +37,6 @@ from .models.gpt_neox.modelings_intervenable_gpt_neox import create_gpt_neox
 from .models.gru.modelings_intervenable_gru import create_gru
 from .models.gru.modelings_intervenable_gru import create_gru_lm
 from .models.gru.modelings_intervenable_gru import create_gru_classifier
+from .models.gru.modelings_gru import GRUConfig
 from .models.llama.modelings_intervenable_llama import create_llama
 from .models.mlp.modelings_intervenable_mlp import create_mlp_classifier

--- a/pyvene/models/configuration_intervenable_model.py
+++ b/pyvene/models/configuration_intervenable_model.py
@@ -1,4 +1,4 @@
-import json, warnings
+import json, warnings, torch
 from collections import OrderedDict, namedtuple
 from typing import Any, List, Mapping, Optional
 
@@ -22,28 +22,37 @@ IntervenableRepresentationConfig = namedtuple(
 class IntervenableConfig(PretrainedConfig):
     def __init__(
         self,
-        intervenable_model_type=None,
         intervenable_representations=[IntervenableRepresentationConfig()],
         intervenable_interventions_type=VanillaIntervention,
         mode="parallel",
         intervenable_interventions=[None],
         sorted_keys=None,
         intervention_dimensions=None,
+        intervenable_model_type=None,
         **kwargs,
     ):
-        self.intervenable_model_type = intervenable_model_type
         self.intervenable_representations = intervenable_representations
         self.intervenable_interventions_type = intervenable_interventions_type
         self.mode = mode
         self.intervenable_interventions = intervenable_interventions
         self.sorted_keys = sorted_keys
         self.intervention_dimensions = intervention_dimensions
+        self.intervenable_model_type = intervenable_model_type
         super().__init__(**kwargs)
 
     def __repr__(self):
+        intervenable_representations = []
+        for r in self.intervenable_representations:
+            new_d = {}
+            for k, v in r._asdict().items():
+                if type(v) not in {str, int, list, tuple, dict} and v is not None and v != [None]:
+                    new_d[k] = "PLACEHOLDER"
+                else:
+                    new_d[k] = v
+                intervenable_representations += [new_d]
         _repr = {
             "intervenable_model_type": str(self.intervenable_model_type),
-            "intervenable_representations": tuple(self.intervenable_representations),
+            "intervenable_representations": tuple(intervenable_representations),
             "intervenable_interventions_type": str(
                 self.intervenable_interventions_type
             ),
@@ -52,9 +61,12 @@ class IntervenableConfig(PretrainedConfig):
                 str(intervenable_intervention)
                 for intervenable_intervention in self.intervenable_interventions
             ],
-            "sorted_keys": tuple(self.sorted_keys),
+            "sorted_keys": tuple(self.sorted_keys) if self.sorted_keys is not None else str(self.sorted_keys),
             "intervention_dimensions": str(self.intervention_dimensions),
         }
         _repr_string = json.dumps(_repr, indent=4)
 
         return f"IntervenableConfig\n{_repr_string}"
+
+    def __str__(self):
+        return self.__repr__()

--- a/pyvene/models/configuration_intervenable_model.py
+++ b/pyvene/models/configuration_intervenable_model.py
@@ -14,8 +14,10 @@ IntervenableRepresentationConfig = namedtuple(
     "intervenable_unit max_number_of_units "
     "intervenable_low_rank_dimension "
     "subspace_partition group_key intervention_link_key intervenable_moe "
-    "source_representation",
-    defaults=(0, "block_output", "pos", 1, None, None, None, None, None, None),
+    "source_representation hidden_source_representation",
+    defaults=(
+        0, "block_output", "pos", 1, 
+        None, None, None, None, None, None, None),
 )
 
 
@@ -31,7 +33,10 @@ class IntervenableConfig(PretrainedConfig):
         intervenable_model_type=None,
         **kwargs,
     ):
-        self.intervenable_representations = intervenable_representations
+        if isinstance(intervenable_representations, list):
+            self.intervenable_representations = intervenable_representations
+        else:
+            self.intervenable_representations = [intervenable_representations]
         self.intervenable_interventions_type = intervenable_interventions_type
         self.mode = mode
         self.intervenable_interventions = intervenable_interventions
@@ -42,14 +47,16 @@ class IntervenableConfig(PretrainedConfig):
 
     def __repr__(self):
         intervenable_representations = []
-        for r in self.intervenable_representations:
+        for reprs in self.intervenable_representations:
+            if isinstance(reprs, list):
+                reprs = IntervenableRepresentationConfig(*reprs)
             new_d = {}
-            for k, v in r._asdict().items():
+            for k, v in reprs._asdict().items():
                 if type(v) not in {str, int, list, tuple, dict} and v is not None and v != [None]:
                     new_d[k] = "PLACEHOLDER"
                 else:
                     new_d[k] = v
-                intervenable_representations += [new_d]
+            intervenable_representations += [new_d]
         _repr = {
             "intervenable_model_type": str(self.intervenable_model_type),
             "intervenable_representations": tuple(intervenable_representations),

--- a/pyvene/models/intervention_utils.py
+++ b/pyvene/models/intervention_utils.py
@@ -62,15 +62,16 @@ def _do_intervention_by_swap(
     """The basic do function that guards interventions"""
     if mode == "collect":
         assert source is None
-    # auto broadcast
-    if base.shape != source.shape:
-        try:
-            source = broadcast_tensor(source, base.shape)
-        except:
-            raise ValueError(
-                f"source with shape {source.shape} cannot be broadcasted "
-                f"into base with shape {base.shape}."
-            )
+    else:
+        # auto broadcast
+        if base.shape != source.shape:
+            try:
+                source = broadcast_tensor(source, base.shape)
+            except:
+                raise ValueError(
+                    f"source with shape {source.shape} cannot be broadcasted "
+                    f"into base with shape {base.shape}."
+                )
     # interchange
     if use_fast:
         if subspaces is not None:

--- a/tutorials/basic_tutorials/Load_Save_and_Share_Interventions.ipynb
+++ b/tutorials/basic_tutorials/Load_Save_and_Share_Interventions.ipynb
@@ -42,28 +42,31 @@
    "execution_count": 2,
    "id": "85db984c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2024-01-11 01:28:17,772] [INFO] [real_accelerator.py:158:get_accelerator] Setting ds_accelerator to cuda (auto detect)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "try:\n",
-    "    # This library is our indicator that the required installs\n",
-    "    # need to be done.\n",
-    "    import pyvene\n",
+    "# try:\n",
+    "#     # This library is our indicator that the required installs\n",
+    "#     # need to be done.\n",
+    "#     import pyvene\n",
     "\n",
-    "except ModuleNotFoundError:\n",
-    "    !pip install git+https://github.com/frankaging/pyvene.git"
+    "# except ModuleNotFoundError:\n",
+    "#     !pip install git+https://github.com/frankaging/pyvene.git"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "b639455b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../..\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "id": "34e47c62",
    "metadata": {},
    "outputs": [
@@ -84,6 +87,7 @@
     "    IntervenableRepresentationConfig,\n",
     "    IntervenableConfig,\n",
     "    VanillaIntervention,\n",
+    "    SubtractionIntervention,\n",
     "    LowRankRotatedSpaceIntervention,\n",
     "    TrainableIntervention,\n",
     ")\n",
@@ -116,14 +120,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "62d35be5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2f532abf49cd46a4851bf7edad6c1520",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HTML(value='<center> <img\\nsrc=https://huggingface.co/front/assets/huggingface_logo-noborder.sv…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from huggingface_hub import notebook_login\n",
     "\n",
     "notebook_login()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc623c7",
+   "metadata": {},
+   "source": [
+    "### Test with complex intervention"
    ]
   },
   {
@@ -183,13 +210,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Directory './tutorial_data/tmp_dir/' created successfully.\n"
+      "Directory './tutorial_data/tmp_dir/' already exists.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "abe3287f068c41408ade09a2c9e023f0",
+       "model_id": "3c7e8b19b333402e902ad1bef9737ada",
        "version_major": 2,
        "version_minor": 0
       },
@@ -211,7 +238,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "30736ca4faad46268b66f21f062a61f5",
+       "model_id": "e9da77567b6a4d3891b30513ea87db66",
        "version_major": 2,
        "version_minor": 0
       },
@@ -253,20 +280,6 @@
    "id": "e4a6c4a8",
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4aadfd6ec3944f2980f8dab3b8d3ecbd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading config.json:   0%|          | 0.00/837 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -320,6 +333,145 @@
     "    counterfactual_outputs_loaded.last_hidden_state,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "521e37a5",
+   "metadata": {},
+   "source": [
+    "### Test with the case config has static source activations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "21363fd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intervenable_config = IntervenableConfig(\n",
+    "    intervenable_model_type=type(gpt),\n",
+    "    intervenable_representations=[\n",
+    "        IntervenableRepresentationConfig(\n",
+    "            0,\n",
+    "            \"block_output\",\n",
+    "            \"pos\",\n",
+    "            1,\n",
+    "            source_representation=torch.rand(768)\n",
+    "        ),\n",
+    "        IntervenableRepresentationConfig(\n",
+    "            2,\n",
+    "            \"block_output\",\n",
+    "            \"pos\",\n",
+    "            1,\n",
+    "            source_representation=torch.rand(768)\n",
+    "        ),\n",
+    "    ],\n",
+    "    intervenable_interventions_type=SubtractionIntervention,\n",
+    ")\n",
+    "intervenable = IntervenableModel(intervenable_config, gpt)\n",
+    "\n",
+    "base = tokenizer(\"The capital of Spain is\", return_tensors=\"pt\")\n",
+    "sources = [tokenizer(\"The capital of Italy is\", return_tensors=\"pt\")]\n",
+    "\n",
+    "_, counterfactual_outputs_unsaved = intervenable(\n",
+    "    base, unit_locations={\"base\": 3}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cb6a3ccb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Saving trainable intervention to intkey_layer.0.repr.block_output.unit.pos.nunit.1#0.bin.\n",
+      "WARNING:root:Saving trainable intervention to intkey_layer.2.repr.block_output.unit.pos.nunit.1#0.bin.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Directory './tutorial_data/tmp_dir_new/' already exists.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# saving it locally as well as to the hub\n",
+    "intervenable.save(\n",
+    "    save_directory=\"./tutorial_data/tmp_dir_new/\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "d3b33fae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:The key is provided in the config. Assuming this is loaded from a pretrained module.\n"
+     ]
+    }
+   ],
+   "source": [
+    "intervenable_loaded = IntervenableModel.load(\n",
+    "    load_directory=\"./tutorial_data/tmp_dir_new/\",\n",
+    "    model=gpt,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "aee40a89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, counterfactual_outputs_loaded = intervenable_loaded(\n",
+    "    base, unit_locations={\"base\": 3}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1d1e8a96",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.equal(\n",
+    "    counterfactual_outputs_unsaved.last_hidden_state,\n",
+    "    counterfactual_outputs_loaded.last_hidden_state,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb8d4d64",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
**Descriptions:**
Simplify generation intervention to have default mode of argument-less with just the base input. The default mode is inference-time intervention where we intervene on each decoding step now.

Cleanup intervention initialization with lazy dict variable passing, instead of hard coded arguments. Refactory existing code for readability.

**Testing Done:**

```  logging.warn(f"Loading trainable intervention from {binary_filename}.")
WARNING:root:Loading trainable intervention from intkey_layer.0.repr.block_output.unit.pos.nunit.1#0.bin.
WARNING:root:Loading trainable intervention from intkey_layer.1.repr.block_output.unit.pos.nunit.1#0.bin.
Directory './test_output_dir_prefix-9647b9' created successfully.
WARNING:root:Saving trainable intervention to intkey_layer.0.repr.block_output.unit.pos.nunit.1#0.bin.
WARNING:root:Saving trainable intervention to intkey_layer.1.repr.block_output.unit.pos.nunit.1#0.bin.
WARNING:root:The key is provided in the config. Assuming this is loaded from a pretrained module.
WARNING:root:Loading trainable intervention from intkey_layer.0.repr.block_output.unit.pos.nunit.1#0.bin.
WARNING:root:Loading trainable intervention from intkey_layer.1.repr.block_output.unit.pos.nunit.1#0.bin.
.Directory './test_output_dir_prefix-2701e4' created successfully.
.Directory './test_output_dir_prefix-87c463' created successfully.
WARNING:root:Saving trainable intervention to intkey_layer.0.repr.block_output.unit.pos.nunit.1#0.bin.
WARNING:root:Saving trainable intervention to intkey_layer.1.repr.block_output.unit.pos.nunit.1#0.bin.
.Removing testing dir ./test_output_dir_prefix-8f8fad
Removing testing dir ./test_output_dir_prefix-364dae
Removing testing dir ./test_output_dir_prefix-9647b9
Removing testing dir ./test_output_dir_prefix-2701e4
Removing testing dir ./test_output_dir_prefix-87c463

----------------------------------------------------------------------
Ran 31 tests in 84.541s

OK```