### PR TITLE
[Bug Fix] Topological order scoring is not accurate

### DIFF
--- a/pyvene/models/modeling_utils.py
+++ b/pyvene/models/modeling_utils.py
@@ -177,12 +177,13 @@ def check_sorted_intervenables_by_topological_order(
 
     scores = {}
     for k, _ in intervenable_representations.items():
-        l = int(k.split(".")[1]) + 1
-        r = TOPOLOGICAL_ORDER.index(k.split(".")[3])
+        l = 100*(int(k.split(".")[1]) + 1)
+        r = 10*TOPOLOGICAL_ORDER.index(k.split(".")[3])
         # incoming order in case they are ordered
-        o = int(k.split("#")[1]) + 1
-        scores[k] = l * r * o
+        o = 1*(int(k.split("#")[1]) + 1)
+        scores[k] = l + r + o
     sorted_keys_by_topological_order = sorted(scores.keys(), key=lambda x: scores[x])
+    
     return sorted_intervenable_keys == sorted_keys_by_topological_order
 
 


### PR DESCRIPTION
**Descriptions:**

Currently sorting thing does not work for path patching configs such as,
```py
def path_patching_config(
    layer, stream="head_attention_value_output", num_layers=gpt.config.n_layer
):
    intervening_component = [
        IntervenableRepresentationConfig(layer, stream, "h.pos", group_key=0)
    ]
    restoring_components = []
    if not stream.startswith("mlp_"):
        restoring_components += [
            IntervenableRepresentationConfig(layer, "mlp_output", group_key=1)
        ]
    for i in range(layer+1, num_layers):
        restoring_components += [
            IntervenableRepresentationConfig(i, "attention_output", group_key=1),
            IntervenableRepresentationConfig(i, "mlp_output", group_key=1)
        ]
    intervenable_config = IntervenableConfig(
        intervenable_representations=intervening_component + restoring_components,
        intervenable_interventions_type=VanillaIntervention,
    )
    return intervenable_config

intervenable_config = path_patching_config(
    layer=4, 
    stream="head_attention_value_output"
)
intervenable = IntervenableModel(intervenable_config, gpt)
```