### PR TITLE
[P0] remove autograd debugging

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -936,7 +936,7 @@ class IntervenableModel(nn.Module):
         activations_sources: Optional[Dict] = None,
         subspaces: Optional[List] = None,
     ):
-        torch.autograd.set_detect_anomaly(True)
+        # torch.autograd.set_detect_anomaly(True)
         all_set_handlers = HandlerList([])
         unit_locations_sources = unit_locations["sources->base"][0]
         unit_locations_base = unit_locations["sources->base"][1]


### PR DESCRIPTION
## Description

There was an autograd debugging line left in that significantly impacted performance. Discovered it while using a profiler to debug experiment speeds. Removing it reduced runtime for training my DAS benchmark work on `pythia-14m` from 289s to 170s!

## Testing Done

No effect on library behaviours at all, just removed `torch.autograd.set_detect_anomaly(True)`.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
