### PR TITLE
[Minor] Adding support for any two-input lambda interventions; ResNet tutorials (no config)

### DIFF
--- a/pyvene/models/mlp/modelings_mlp.py
+++ b/pyvene/models/mlp/modelings_mlp.py
@@ -7,7 +7,7 @@ from transformers import PretrainedConfig, PreTrainedModel
 from transformers.activations import ACT2FN
 from transformers.utils import ModelOutput
 from transformers.modeling_outputs import SequenceClassifierOutput
-
+from dataclasses import dataclass
 
 class MLPConfig(PretrainedConfig):
     model_type = "mlp"
@@ -40,7 +40,7 @@ class MLPConfig(PretrainedConfig):
         self.squeeze_output = squeeze_output
         super().__init__(**kwargs)
 
-
+@dataclass
 class MLPModelOutput(ModelOutput):
     last_hidden_state: torch.FloatTensor = None
     hidden_states: Optional[Tuple[torch.FloatTensor]] = None

--- a/pyvene/models/modeling_utils.py
+++ b/pyvene/models/modeling_utils.py
@@ -1,4 +1,4 @@
-import random, torch
+import random, torch, types
 import numpy as np
 from torch import nn
 from .intervenable_modelcard import *
@@ -420,6 +420,9 @@ def do_intervention(
 ):
     """Do the actual intervention."""
 
+    if isinstance(intervention, types.FunctionType):
+        return intervention(base_representation, source_representation)
+    
     num_unit = base_representation.shape[1]
 
     # flatten
@@ -441,14 +444,9 @@ def do_intervention(
     else:
         assert False  # what's going on?
     
-    if subspaces is None:
-        intervened_representation = intervention(
-            base_representation_f, source_representation_f
-        )
-    else:
-        intervened_representation = intervention(
-            base_representation_f, source_representation_f, subspaces
-        )
+    intervened_representation = intervention(
+        base_representation_f, source_representation_f, subspaces
+    )
 
     post_d = intervened_representation.shape[-1]
 

--- a/pyvene/models/modeling_utils.py
+++ b/pyvene/models/modeling_utils.py
@@ -130,6 +130,7 @@ def get_dimension_by_component(model_type, model_config, component) -> int:
 def get_module_hook(model, representation) -> nn.Module:
     """Render the intervening module with a hook."""
     if (
+        get_internal_model_type(model) in type_to_module_mapping and
         representation.component
         in type_to_module_mapping[get_internal_model_type(model)]
     ):
@@ -439,10 +440,15 @@ def do_intervention(
         source_representation_f = bhsd_to_bs_hd(source_representation)
     else:
         assert False  # what's going on?
-
-    intervened_representation = intervention(
-        base_representation_f, source_representation_f, subspaces
-    )
+    
+    if subspaces is None:
+        intervened_representation = intervention(
+            base_representation_f, source_representation_f
+        )
+    else:
+        intervened_representation = intervention(
+            base_representation_f, source_representation_f, subspaces
+        )
 
     post_d = intervened_representation.shape[-1]
 

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "id": "17c7f2f6-b0d3-4fe2-8e4f-c044b93f3ef0",
    "metadata": {},
    "outputs": [
@@ -148,7 +148,7 @@
     "base = \"When John and Mary went to the shops, Mary gave the bag to\"\n",
     "collected_attn_w = pv_gpt2(\n",
     "    base = tokenizer(base, return_tensors=\"pt\"\n",
-    "    ), unit_locations={\"base\": ([[[h for h in range(12)]]])}\n",
+    "    ), unit_locations={\"base\": [h for h in range(12)]}\n",
     ")[0][-1][0]"
    ]
   },
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 15,
    "id": "1ef4a1db-5187-4457-9878-f1dc03e9859b",
    "metadata": {},
    "outputs": [
@@ -195,7 +195,7 @@
        ")"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 19,
    "id": "128be2dd-f089-4291-bfc5-7002d031b1e9",
    "metadata": {},
    "outputs": [
@@ -232,8 +232,47 @@
     "base = \"When John and Mary went to the shops, Mary gave the bag to\"\n",
     "collected_attn_w = pv_gpt2(\n",
     "    base = tokenizer(base, return_tensors=\"pt\"\n",
-    "    ), unit_locations={\"base\": ([[[h for h in range(12)]]])}\n",
+    "    ), unit_locations={\"base\": [h for h in range(12)]}\n",
     ")[0][-1][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef19f251",
+   "metadata": {},
+   "source": [
+    "#### Get Attention Weights with a Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ef0667c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loaded model\n"
+     ]
+    }
+   ],
+   "source": [
+    "import copy\n",
+    "import pyvene as pv\n",
+    "\n",
+    "_, tokenizer, gpt2 = pv.create_gpt2()\n",
+    "\n",
+    "cached_w = {}\n",
+    "def pv_patcher(b, s): cached_w[\"attn_w\"] = copy.deepcopy(b.data)\n",
+    "\n",
+    "pv_gpt2 = pv.IntervenableModel({\n",
+    "    \"component\": \"h[10].attn.attn_dropout.input\", \n",
+    "    \"intervention\": pv_patcher}, model=gpt2)\n",
+    "\n",
+    "base = \"When John and Mary went to the shops, Mary gave the bag to\"\n",
+    "_ = pv_gpt2(tokenizer(base, return_tensors=\"pt\"))"
    ]
   },
   {
@@ -2284,24 +2323,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 11,
    "id": "bfb48112",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Detected is_sequence_model=False means you are intervening a non-sequence-based NNs (e.g., MLPs, ConvNet and ResNet) where there is no second dimension representing the sequence length.\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "tensor(-0.0025)"
+       "tensor(0.0005)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2323,15 +2355,15 @@
     "source_inputs['pixel_values'] += 0.5*torch.randn(source_inputs['pixel_values'].shape)\n",
     "\n",
     "def create_mask():\n",
-    "    _mask = torch.zeros((56, 3584))\n",
-    "    _mask[:, 3584//2:] = 1\n",
+    "    _mask = torch.zeros((56, 56))\n",
+    "    _mask[56//2:, 56//2:] = 1\n",
     "    return _mask\n",
     "m = create_mask()\n",
     "\n",
     "pv_resnet = pv.IntervenableModel({\n",
     "    \"component\": \"resnet.embedder.pooler.output\", \n",
     "    \"intervention\": lambda b, s: b * (1. - m) + s * m}, \n",
-    "    model=resnet, is_sequence_model=False\n",
+    "    model=resnet\n",
     ")\n",
     "intervened_outputs = pv_resnet(\n",
     "    base_inputs, [source_inputs], return_dict=True\n",
@@ -2349,16 +2381,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 12,
    "id": "6d0095f3",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:Detected is_sequence_model=False means you are intervening a non-sequence-based NNs (e.g., MLPs, ConvNet and ResNet) where there is no second dimension representing the sequence length.\n"
-     ]
+     "data": {
+      "text/plain": [
+       "tensor(0.0068, grad_fn=<SumBackward0>)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -2379,12 +2414,12 @@
     "\n",
     "# trainable DAS directions\n",
     "v = torch.nn.utils.parametrizations.orthogonal(\n",
-    "    torch.nn.Linear(3584, 10))\n",
+    "    torch.nn.Linear(56, 10))\n",
     "\n",
     "pv_resnet = pv.IntervenableModel({\n",
     "    \"component\": \"resnet.embedder.pooler.output\", \n",
     "    \"intervention\": lambda b, s: b + ((s @ v.weight.T - b @ v.weight.T) @ v.weight)}, \n",
-    "    model=resnet, is_sequence_model=False\n",
+    "    model=resnet\n",
     ")\n",
     "\n",
     "intervened_outputs = pv_resnet(\n",

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -110,7 +110,8 @@
     "- **Source** example or representations: this is the source of our intervention. We use **Source** to intervene on **Base**.\n",
     "- **component**: this is the `nn.module` we are intervening in a pytorch-based NN. For models supported by this library, you can use directly access via str, or use the abstract names defined in the config file (e.g., `h[0].mlp.output` or `mlp_output` with other fields). \n",
     "- **unit**: this is the axis of our intervention. If we say our **unit** is `pos` (`position`), then you are intervening on each token position.\n",
-    "- **unit_locations**: this list gives you the percisely location of your intervention. It is the locations of the unit of analysis you are specifying. For instance, if your `unit` is `pos`, and your `unit_location` is 3, then it means you are intervening on the third token."
+    "- **unit_locations**: this list gives you the percisely location of your intervention. It is the locations of the unit of analysis you are specifying. For instance, if your `unit` is `pos`, and your `unit_location` is 3, then it means you are intervening on the third token. If this field is left as `None`, then no selection will be taken, i.e., you can think of you are getting the raw tensor and you can do whatever you want.\n",
+    "- **intervention_type** or **intervention**: this field specifies the intervention you can perform. It can be a primitive type, or it can be a function or a lambda expression for simple interventions. One benefit of using primitives is speed and systematic training schemes. You can also save and load interventions if you use the supported primitives."
    ]
   },
   {
@@ -238,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef19f251",
+   "id": "22643b2d",
    "metadata": {},
    "source": [
     "#### Get Attention Weights with a Function"
@@ -247,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ef0667c7",
+   "id": "678dc46f",
    "metadata": {},
    "outputs": [
     {

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -19,13 +19,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "id": "d123a2ba",
    "metadata": {},
    "outputs": [],
    "source": [
     "__author__ = \"Zhengxuan Wu\"\n",
-    "__version__ = \"01/20/2024\""
+    "__version__ = \"02/01/2024\""
    ]
   },
   {
@@ -69,6 +69,8 @@
     "    1. [Inference-time Intervention](#Inference-time-Intervention)\n",
     "    1. [IntervenableModel from HuggingFace Directly](#IntervenableModel-from-HuggingFace-Directly)\n",
     "    1. [Path Patching with DAS](#Path-Patching-with-Trainable-Interventions)\n",
+    "    1. [Intervene ResNet with Lambda Functors](#Intervene-on-ResNet-with-Lambda-Functions)\n",
+    "    1. [Intervene ResNet with 1-line DAS Lambda](#Intervene-on-ResNet-with-Trainable-Lambda-Functions)\n",
     "1. [The End](#The-End)\n",
     "    "
    ]
@@ -2266,6 +2268,129 @@
     ")\n",
     "# put gradients on the trainable intervention only\n",
     "counterfactual_outputs[0].sum().backward()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0907a98c",
+   "metadata": {},
+   "source": [
+    "### Intervene on ResNet with Lambda Functions\n",
+    "\n",
+    "Huggingface Vision model comes with the support of ResNet. Here, we show how we can use pyvene to intervene on a patch of pixels, like token in transformer, which is like a primitive object in ResNet or ConvNet based NNs.\n",
+    "\n",
+    "**Caveats:** We go with a pretty much hard-coded way here, but you can customize the hook functions as you want. It does not have to be a lambda function as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "bfb48112",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Detected is_sequence_model=False means you are intervening a non-sequence-based NNs (e.g., MLPs, ConvNet and ResNet) where there is no second dimension representing the sequence length.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "tensor(-0.0025)"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pyvene as pv\n",
+    "from datasets import load_dataset\n",
+    "from transformers import AutoFeatureExtractor, AutoModelForImageClassification\n",
+    "\n",
+    "feature_extractor = AutoFeatureExtractor.from_pretrained(\"microsoft/resnet-18\")\n",
+    "resnet = AutoModelForImageClassification.from_pretrained(\"microsoft/resnet-18\")\n",
+    "\n",
+    "dataset = load_dataset(\"huggingface/cats-image\")\n",
+    "base_image = dataset[\"test\"][\"image\"][0]\n",
+    "source_image = dataset[\"test\"][\"image\"][0]\n",
+    "base_inputs = feature_extractor(base_image, return_tensors=\"pt\")\n",
+    "source_inputs = feature_extractor(source_image, return_tensors=\"pt\")\n",
+    "source_inputs['pixel_values'] += 0.5*torch.randn(source_inputs['pixel_values'].shape)\n",
+    "\n",
+    "def create_mask():\n",
+    "    _mask = torch.zeros((56, 3584))\n",
+    "    _mask[:, 3584//2:] = 1\n",
+    "    return _mask\n",
+    "m = create_mask()\n",
+    "\n",
+    "pv_resnet = pv.IntervenableModel({\n",
+    "    \"component\": \"resnet.embedder.pooler.output\", \n",
+    "    \"intervention\": lambda b, s: b * (1. - m) + s * m}, \n",
+    "    model=resnet, is_sequence_model=False\n",
+    ")\n",
+    "intervened_outputs = pv_resnet(\n",
+    "    base_inputs, [source_inputs], return_dict=True\n",
+    ")\n",
+    "(intervened_outputs.intervened_outputs.logits - intervened_outputs.original_outputs.logits).sum()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4d0aa78",
+   "metadata": {},
+   "source": [
+    "### Intervene on ResNet with Trainable Lambda Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "6d0095f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:root:Detected is_sequence_model=False means you are intervening a non-sequence-based NNs (e.g., MLPs, ConvNet and ResNet) where there is no second dimension representing the sequence length.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pyvene as pv\n",
+    "from datasets import load_dataset\n",
+    "from transformers import AutoFeatureExtractor, AutoModelForImageClassification\n",
+    "\n",
+    "feature_extractor = AutoFeatureExtractor.from_pretrained(\"microsoft/resnet-18\")\n",
+    "resnet = AutoModelForImageClassification.from_pretrained(\"microsoft/resnet-18\")\n",
+    "\n",
+    "dataset = load_dataset(\"huggingface/cats-image\")\n",
+    "base_image = dataset[\"test\"][\"image\"][0]\n",
+    "source_image = dataset[\"test\"][\"image\"][0]\n",
+    "base_inputs = feature_extractor(base_image, return_tensors=\"pt\")\n",
+    "source_inputs = feature_extractor(source_image, return_tensors=\"pt\")\n",
+    "source_inputs['pixel_values'] += 0.5*torch.randn(source_inputs['pixel_values'].shape)\n",
+    "\n",
+    "# trainable DAS directions\n",
+    "v = torch.nn.utils.parametrizations.orthogonal(\n",
+    "    torch.nn.Linear(3584, 10))\n",
+    "\n",
+    "pv_resnet = pv.IntervenableModel({\n",
+    "    \"component\": \"resnet.embedder.pooler.output\", \n",
+    "    \"intervention\": lambda b, s: b + ((s @ v.weight.T - b @ v.weight.T) @ v.weight)}, \n",
+    "    model=resnet, is_sequence_model=False\n",
+    ")\n",
+    "\n",
+    "intervened_outputs = pv_resnet(\n",
+    "    base_inputs, [source_inputs], return_dict=True\n",
+    ")\n",
+    "(intervened_outputs.intervened_outputs.logits - intervened_outputs.original_outputs.logits).sum()"
    ]
   },
   {

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -37,8 +37,10 @@
     "1. [Set-up](#Set-up)     \n",
     "1. [pyvene 101](#pyvene-101) \n",
     "    1. [Get Attention Weights](#Get-Attention-Weights)\n",
-    "        1. [Get Attention Weights with String Access](#Get-Attention-Weights-with-Direct-Access-String)\n",
+    "        1. [with String Access](#Get-Attention-Weights-with-Direct-Access-String)\n",
+    "        1. [with 1-Line Function](#Get-Attention-Weights-with-a-Function)\n",
     "    1. [Set Activations to Zeros](#Set-Activation-to-Zeros) \n",
+    "        1. [with Lambda Expression](#Set-Activation-to-Zeros-with-a-Lambda-Expression)\n",
     "    1. [Set Activations with Subspaces](#Set-Activations-to-Zeros-with-Subspaces)\n",
     "    1. [Interchange Intervention](#Interchange-Interventions)\n",
     "    1. [Intervention Config](#Intervention-Configuration)\n",
@@ -124,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "17c7f2f6-b0d3-4fe2-8e4f-c044b93f3ef0",
    "metadata": {},
    "outputs": [
@@ -247,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 22,
    "id": "678dc46f",
    "metadata": {},
    "outputs": [
@@ -273,7 +275,8 @@
     "    \"intervention\": pv_patcher}, model=gpt2)\n",
     "\n",
     "base = \"When John and Mary went to the shops, Mary gave the bag to\"\n",
-    "_ = pv_gpt2(tokenizer(base, return_tensors=\"pt\"))"
+    "_ = pv_gpt2(tokenizer(base, return_tensors=\"pt\"))\n",
+    "torch.allclose(collected_attn_w, cached_w[\"attn_w\"].unsqueeze(dim=0))"
    ]
   },
   {
@@ -286,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 39,
    "id": "a82664f9",
    "metadata": {},
    "outputs": [
@@ -314,6 +317,61 @@
     "    base = tokenizer(\"The capital of Spain is\", return_tensors=\"pt\"), \n",
     "    # we define the intervening token dynamically\n",
     "    unit_locations={\"base\": 3}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9c11cb9",
+   "metadata": {},
+   "source": [
+    "#### Set Activation to Zeros with a Lambda Expression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "7627dc32",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loaded model\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pyvene as pv\n",
+    "\n",
+    "_, tokenizer, gpt2 = pv.create_gpt2()\n",
+    "\n",
+    "# indices are specified in the intervention\n",
+    "mask = torch.ones(1, 5, 768)\n",
+    "mask[:,3,:] = 0.\n",
+    "# define the component to zero-out\n",
+    "pv_gpt2 = pv.IntervenableModel({\n",
+    "    \"component\": \"h[0].mlp.output\", \"intervention\": lambda b, s: b*mask\n",
+    "}, model=gpt2)\n",
+    "# run the intervened forward pass\n",
+    "intervened_outputs_fn = pv_gpt2(\n",
+    "    base = tokenizer(\"The capital of Spain is\", return_tensors=\"pt\")\n",
+    ")\n",
+    "torch.allclose(\n",
+    "    intervened_outputs[1].last_hidden_state, \n",
+    "    intervened_outputs_fn[1].last_hidden_state\n",
     ")"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt', 'r', encoding='utf-8') as f:
 
 setup(
     name="pyvene",
-    version="0.0.7",
+    version="0.0.8dev",
     description="Use Activation Intervention to Interpret Causal Mechanism of Model",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/unit_tests/InterventionUtilsTestCase.py
+++ b/tests/unit_tests/InterventionUtilsTestCase.py
@@ -7,6 +7,7 @@ from pyvene.models.interventions import CollectIntervention
 
 
 class InterventionUtilsTestCase(unittest.TestCase):
+    
     @classmethod
     def setUpClass(self):
         print("=== Test Suite: InterventionUtilsTestCase ===")

--- a/tests/unit_tests/InterventionUtilsTestCase.py
+++ b/tests/unit_tests/InterventionUtilsTestCase.py
@@ -9,7 +9,7 @@ from pyvene.models.interventions import CollectIntervention
 class InterventionUtilsTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        print("=== Test Suite: IntervenableUnitTestCase ===")
+        print("=== Test Suite: InterventionUtilsTestCase ===")
         self.config, self.tokenizer, self.gpt2 = create_gpt2_lm(
             config=GPT2Config(
                 n_embd=24,


### PR DESCRIPTION
## Description

Currently, we expose the APIs in the way that prioritizes intervention serializations, which means we can only use intervention primitives defined in pyvene which limits customizable intervention types. Although people can define interventions as `nn.Modules`, it takes more efforts comparing to a simple function, or lambda expression. 

This change introduces how to interact with pyvene with a one-line lambda expression-based intervention which can also do trainable interventions with more customizable formats. At this point, pyvene basically acts like a `torch.hook` manager only losing its ability to share and save. Yet, it can easily support those simple interventions that are designed to be customizable.

## Testing Done

```
       grad_fn=<AddBackward0>)
./juice/scr/wuzhengx/pyvene/pyvene/models/interventions.py:421: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  mask_sigmoid = torch.sigmoid(self.mask / torch.tensor(self.temperature))
.........Removing testing dir ./test_output_dir_prefix-2891ac
Removing testing dir ./test_output_dir_prefix-169855
Removing testing dir ./test_output_dir_prefix-6f0ab4
Removing testing dir ./test_output_dir_prefix-be15ba
Removing testing dir ./test_output_dir_prefix-50bb90
.............
----------------------------------------------------------------------
Ran 63 tests in 44.468s

OK
```

- Added in tutorials in pyvene-101.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
