### PR TITLE
[P1] Added BLIP-ITM model definitions

### DIFF
--- a/pyvene/__init__.py
+++ b/pyvene/__init__.py
@@ -35,6 +35,7 @@ from .models.intervenable_modelcard import type_to_module_mapping, type_to_dimen
 from .models.gpt2.modelings_intervenable_gpt2 import create_gpt2
 from .models.gpt2.modelings_intervenable_gpt2 import create_gpt2_lm
 from .models.blip.modelings_intervenable_blip import create_blip
+from .models.blip.modelings_intervenable_blip_itm import create_blip_itm
 from .models.gpt_neo.modelings_intervenable_gpt_neo import create_gpt_neo
 from .models.gpt_neox.modelings_intervenable_gpt_neox import create_gpt_neox
 from .models.gru.modelings_intervenable_gru import create_gru

--- a/pyvene/models/blip/modelings_blip_itm.py
+++ b/pyvene/models/blip/modelings_blip_itm.py
@@ -1,0 +1,105 @@
+import torch
+import torch.nn as nn
+from transformers import BlipConfig, BlipForImageTextRetrieval
+from transformers.utils import ModelOutput
+from typing import Optional, Union, Tuple, Dict
+
+
+class BlipITMWrapper(nn.Module):
+    def __init__(
+        self, model: BlipForImageTextRetrieval, use_itm_not_contrastive: bool = True
+    ):
+        super(BlipITMWrapper, self).__init__()
+        self.model_vis = model.vision_model
+        self.model_text_enc = model.text_encoder
+        self.model_vis_proj = model.vision_proj
+        self.model_text_proj = model.text_proj
+        self.model_itm = model.itm_head
+        # do I need to keep decoder_pad_token_id and decoder_start_token_id? might be a mistake in the HF implementation lol
+        self.config = model.config
+        self.eos_token_id = (model.config.text_config.sep_token_id,)
+        self.pad_token_id = model.config.text_config.pad_token_id
+        self.output_attentions = model.config.output_attentions
+        self.use_return_dict = model.config.use_return_dict
+        self.output_hidden_states = model.config.output_hidden_states
+
+        self.use_itm_head = use_itm_not_contrastive
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        pixel_values: torch.FloatTensor,
+        attention_mask: Optional[torch.LongTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, Dict]:
+        return_dict = return_dict if return_dict is not None else self.use_return_dict
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.output_hidden_states
+        )
+
+        vision_outputs = self.model_vis(
+            pixel_values=pixel_values,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        image_embeds = vision_outputs[0].to(self.model_text_enc.device)
+        input_ids = input_ids.to(self.model_text_enc.device)
+        
+        if self.use_itm_head:
+            image_attention_mask = torch.ones(
+                image_embeds.size()[:-1], dtype=torch.long
+            )
+
+            caption_embeds = self.model_text_enc(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                encoder_hidden_states=image_embeds,
+                encoder_attention_mask=image_attention_mask,
+                output_hidden_states=True,
+            )
+            caption_embeds = (
+                caption_embeds[0]
+                if not return_dict
+                else caption_embeds.last_hidden_state
+            )
+
+            output = self.model_itm(caption_embeds[:, 0, :])
+        else:
+            caption_embeds = self.model_text_enc(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                return_dict=return_dict,
+                output_hidden_states=True,
+            )
+            caption_embeds = (
+                caption_embeds[0]
+                if not return_dict
+                else caption_embeds.last_hidden_state
+            )
+
+            image_feat = nn.functional.normalize(
+                self.vision_proj(image_embeds[:, 0, :]), dim=-1
+            )
+            text_feat = nn.functional.normalize(
+                self.text_proj(caption_embeds[:, 0, :]), dim=-1
+            )
+
+            output = image_feat @ text_feat.t()
+
+        return {
+            "itm_score": output,
+            "image_embeds": image_embeds,
+            "encoder_last_hidden_state": caption_embeds.last_hidden_state,
+            "encoder_hidden_states": caption_embeds.hidden_states,
+        }

--- a/pyvene/models/blip/modelings_intervenable_blip.py
+++ b/pyvene/models/blip/modelings_intervenable_blip.py
@@ -100,7 +100,7 @@ blip_wrapper_type_to_dimension_mapping = blip_type_to_dimension_mapping
 
 
 def create_blip(name="Salesforce/blip-vqa-base", cache_dir=None):
-    """Creates a GPT2 model, config, and tokenizer from the given name and revision"""
+    """Creates a BLIP VQA model, config, and tokenizer from the given name and revision"""
     from transformers import BlipConfig, BlipProcessor, BlipForQuestionAnswering
 
     config = BlipConfig.from_pretrained(name)

--- a/pyvene/models/blip/modelings_intervenable_blip_itm.py
+++ b/pyvene/models/blip/modelings_intervenable_blip_itm.py
@@ -1,0 +1,96 @@
+"""
+Each modeling file in this library is a mapping between
+abstract naming of intervention anchor points and actual
+model module defined in the huggingface library.
+
+We also want to let the intervention library know how to
+config the dimensions of intervention based on model config
+defined in the huggingface library.
+"""
+
+from ..constants import *
+
+"""blip ITM base model"""
+blip_itm_type_to_module_mapping = {
+    # TODO: not sure why these are commented out in the BlipVQA implementation
+    # 'vis.block_input': ("vision_model.encoder.layers[%s]", CONST_INPUT_HOOK),
+    # 'vis.block_output': ("vision_model.encoder.layers[%s]", CONST_OUTPUT_HOOK),
+    # 'vis.mlp_activation': ("vision_model.encoder.layers[%s].mlp.fc1", CONST_OUTPUT_HOOK),
+    # 'vis.mlp_output': ("vision_model.encoder.layers[%s].mlp", CONST_OUTPUT_HOOK),
+    # 'vis.mlp_input': ("vision_model.encoder.layers[%s].mlp", CONST_INPUT_HOOK),
+    # 'vis.attention_value_output': ("vision_model.encoder.layers[%s].self_attn.projection", CONST_INPUT_HOOK),
+    # 'vis.attention_output': ("vision_model.encoder.layers[%s].self_attn", CONST_OUTPUT_HOOK),
+    # 'vis.attention_input': ("vision_model.encoder.layers[%s].self_attn", CONST_INPUT_HOOK),
+    "block_input": ("text_encoder.encoder.layer[%s]", CONST_INPUT_HOOK),
+    "block_output": ("text_encoder.encoder.layer[%s]", CONST_INPUT_HOOK),
+    "mlp_activation": (
+        "text_encoder.encoder.layer[%s].intermediate.dense",
+        CONST_OUTPUT_HOOK,
+    ),
+    "mlp_output": ("text_encoder.encoder.layer[%s].output", CONST_OUTPUT_HOOK),
+    "mlp_input": ("text_encoder.encoder.layer[%s].intermediate", CONST_INPUT_HOOK),
+    "attention_value_output": (
+        "text_encoder.encoder.layer[%s].attention.output.dense",
+        CONST_INPUT_HOOK,
+    ),
+    "attention_output": (
+        "text_encoder.encoder.layer[%s].attention.output",
+        CONST_OUTPUT_HOOK,
+    ),
+    "attention_input": ("text_encoder.encoder.layer[%s].attention", CONST_INPUT_HOOK),
+    "itm_output": ("itm_head", CONST_OUTPUT_HOOK),
+}
+
+
+blip_itm_type_to_dimension_mapping = {
+    # 'vis.block_input': ("image_text_hidden_size", ),
+    # 'vis.block_output': ("image_text_hidden_size", ),
+    # 'vis.mlp_activation': ("projection_dim", ),
+    # 'vis.mlp_output': ("image_text_hidden_size", ),
+    # 'vis.mlp_input': ("image_text_hidden_size", ),
+    # 'vis.attention_value_output': ("image_text_hidden_size/text_config.num_attention_heads", ),
+    # 'vis.attention_output': ("image_text_hidden_size", ),
+    # 'vis.attention_input': ("image_text_hidden_size", ),
+    "block_input": ("image_text_hidden_size",),
+    "block_output": ("image_text_hidden_size",),
+    "mlp_activation": ("projection_dim",),
+    "mlp_output": ("image_text_hidden_size",),
+    "mlp_input": ("image_text_hidden_size",),
+    "attention_value_output": (
+        "image_text_hidden_size/text_config.num_attention_heads",
+    ),
+    "attention_output": ("image_text_hidden_size",),
+    "attention_input": ("image_text_hidden_size",),
+    "cross_attention_value_output": (
+        "image_text_hidden_size/text_config.num_attention_heads",
+    ),
+    "cross_attention_output": ("image_text_hidden_size",),
+    "cross_attention_input": ("image_text_hidden_size",),
+    "itm_input": ("image_text_hidden_size",),
+    "itm_output": (2,), # TODO: not sure how to specify this dim as it's not an attr in BlipConfig
+}
+
+
+"""blip model with wrapper"""
+blip_itm_wrapper_type_to_module_mapping = {}
+for k, v in blip_itm_type_to_module_mapping.items():
+    blip_itm_wrapper_type_to_module_mapping[k] = (
+        v[0].replace("text_encoder", "model_text_enc"), # NOTE: don't fully understand why we do this
+        v[1],
+    )
+
+
+blip_itm_wrapper_type_to_dimension_mapping = blip_itm_type_to_dimension_mapping
+
+
+def create_blip_itm(name="Salesforce/blip-itm-base-coco", cache_dir=None):
+    """Creates a BLIP ITM model, config, and tokenizer from the given name and revision"""
+    from transformers import BlipConfig, BlipProcessor, BlipForImageTextRetrieval
+
+    config = BlipConfig.from_pretrained(name)
+    processor = BlipProcessor.from_pretrained(name)
+    blip = BlipForImageTextRetrieval.from_pretrained(
+        name, config=config, cache_dir=cache_dir
+    )
+    print("loaded model")
+    return config, processor, blip

--- a/pyvene/models/intervenable_modelcard.py
+++ b/pyvene/models/intervenable_modelcard.py
@@ -6,6 +6,7 @@ from .gpt_neox.modelings_intervenable_gpt_neox import *
 from .mlp.modelings_intervenable_mlp import *
 from .gru.modelings_intervenable_gru import *
 from .blip.modelings_intervenable_blip import *
+from .blip.modelings_intervenable_blip_itm import *
 from .backpack_gpt2.modelings_intervenable_backpack_gpt2 import *
 
 
@@ -20,6 +21,7 @@ things that need to be changed.
 
 import transformers.models as hf_models
 from .blip.modelings_blip import BlipWrapper
+from .blip.modelings_blip_itm import BlipITMWrapper
 from .mlp.modelings_mlp import MLPModel, MLPForClassification
 from .gru.modelings_gru import GRUModel, GRULMHeadModel, GRUForClassification
 from .backpack_gpt2.modelings_backpack_gpt2 import BackpackGPT2LMHeadModel
@@ -40,7 +42,9 @@ type_to_module_mapping = {
     hf_models.gpt_neox.modeling_gpt_neox.GPTNeoXModel: gpt_neox_type_to_module_mapping,
     hf_models.gpt_neox.modeling_gpt_neox.GPTNeoXForCausalLM: gpt_neox_lm_type_to_module_mapping,
     hf_models.blip.modeling_blip.BlipForQuestionAnswering: blip_type_to_module_mapping,
+    hf_models.blip.modeling_blip.BlipForImageTextRetrieval: blip_itm_type_to_module_mapping,
     BlipWrapper: blip_wrapper_type_to_module_mapping,
+    BlipITMWrapper: blip_itm_wrapper_type_to_module_mapping,
     MLPModel: mlp_type_to_module_mapping,
     MLPForClassification: mlp_classifier_type_to_module_mapping,
     GRUModel: gru_type_to_module_mapping,
@@ -61,7 +65,9 @@ type_to_dimension_mapping = {
     hf_models.gpt_neox.modeling_gpt_neox.GPTNeoXModel: gpt_neox_type_to_dimension_mapping,
     hf_models.gpt_neox.modeling_gpt_neox.GPTNeoXForCausalLM: gpt_neox_lm_type_to_dimension_mapping,
     hf_models.blip.modeling_blip.BlipForQuestionAnswering: blip_type_to_dimension_mapping,
+    hf_models.blip.modeling_blip.BlipForImageTextRetrieval: blip_itm_type_to_dimension_mapping,
     BlipWrapper: blip_wrapper_type_to_dimension_mapping,
+    BlipITMWrapper: blip_itm_wrapper_type_to_dimension_mapping,
     MLPModel: mlp_type_to_dimension_mapping,
     MLPForClassification: mlp_classifier_type_to_dimension_mapping,
     GRUModel: gru_type_to_dimension_mapping,


### PR DESCRIPTION
## Description

Current BLIP implementation by @aryamanarora is for VQA, but our upcoming experiments with ColorSwap will require BLIP-ITM. I've added new model definition files specifically for the BLIP-ITM setup, as it's fairly different in architecture (vis enc -> text enc -> ITM head) from BLIP-VQA (vis enc -> text enc -> text dec). It's probably possible to capture both of them with a single general definition, but I wanted to take the lowest risk path for my first PR.

## Testing Done

Haven't added any tests or done any testing yet. Just wanted to open a PR with the [mostly complete] work I've done already as it's Sunday night and I'm not sure when I'll be able to get back around to this next.

## Checklist:

- [X] My PR title strictly follows the format: `[Your Priority] Your Title`
- [ ] I have attached the testing log above
- [X] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes