### PR TITLE
[Minor] Fix typo in the voting tutorial; fix a bug in generation

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -653,7 +653,7 @@ class IntervenableModel(nn.Module):
             def hook_callback(model, args, kwargs, output=None):
                 if self._is_generation:
                     pass
-                    # for activation recording, we allow
+                    # for getter, there is no restriction.
                     # is_prompt = self._key_getter_call_counter[key] == 0
                     # if not self._intervene_on_prompt or is_prompt:
                     #     self._key_getter_call_counter[key] += 1

--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -652,11 +652,13 @@ class IntervenableModel(nn.Module):
 
             def hook_callback(model, args, kwargs, output=None):
                 if self._is_generation:
-                    is_prompt = self._key_getter_call_counter[key] == 0
-                    if not self._intervene_on_prompt or is_prompt:
-                        self._key_getter_call_counter[key] += 1
-                    if self._intervene_on_prompt ^ is_prompt:
-                        return  # no-op
+                    pass
+                    # for activation recording, we allow
+                    # is_prompt = self._key_getter_call_counter[key] == 0
+                    # if not self._intervene_on_prompt or is_prompt:
+                    #     self._key_getter_call_counter[key] += 1
+                    # if self._intervene_on_prompt ^ is_prompt:
+                    #     return  # no-op
                 if output is None:
                     if len(args) == 0:  # kwargs based calls
                         # PR: https://github.com/frankaging/align-transformers/issues/11
@@ -1509,7 +1511,6 @@ class IntervenableModel(nn.Module):
                         CollectIntervention
                     ):
                         collected_activations += self.activations[key]
-            
         except Exception as e:
             raise e
         finally:

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -1007,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "id": "f718e2d6",
    "metadata": {},
    "outputs": [
@@ -1015,8 +1015,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/sailhome/wuzhengx/.local/lib/python3.8/site-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n",
-      "  return self.fget.__get__(instance, owner)()\n",
       "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
       "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n"
      ]
@@ -1082,6 +1080,93 @@
     "    \"Once upon a time there was\", return_tensors=\"pt\")\n",
     "_, intervened_story = pv_tinystory.generate(\n",
     "    prompt, source_representations=emb_happy*0.3, max_length=256\n",
+    ")\n",
+    "\n",
+    "print(tokenizer.decode(\n",
+    "    intervened_story[0], \n",
+    "    skip_special_tokens=True\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e628990d",
+   "metadata": {},
+   "source": [
+    "intervene on generation with source example passed in. The result will be slightly different since we no longer have a static vector to be added in; it is layerwise addition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "087541f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loaded model\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Once upon a time there was a little girl named Lucy. She was very excited because she was going to the park. She wanted to go to the park and play.\n",
+      "\n",
+      "When she got to the park, she saw a big slide. She was so excited! She ran to the slide and started to climb up. She was so happy.\n",
+      "\n",
+      "But then she saw something else. It was a big, scary dog. It was a big, mean dog. He was barking and growling at her. Lucy was scared. She didn't know what to do.\n",
+      "\n",
+      "Suddenly, she heard a voice. It was her mommy. She said, \"Don't worry, Lucy. I will help you. I will protect you.\"\n",
+      "\n",
+      "Lucy was so happy. She hugged her mommy and they went to the park. They played together and had lots of fun. Lucy was so happy. She was no longer scared.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pyvene as pv\n",
+    "\n",
+    "# built-in helper to get tinystore\n",
+    "_, tokenizer, tinystory = pv.create_gpt_neo()\n",
+    "\n",
+    "def pv_patcher(b, s): return b + s*0.1\n",
+    "\n",
+    "pv_tinystory = pv.IntervenableModel([{\n",
+    "    \"layer\": l,\n",
+    "    \"component\": \"mlp_output\",\n",
+    "    \"intervention\": pv_patcher\n",
+    "    } for l in range(tinystory.config.num_layers)],\n",
+    "    model=tinystory\n",
+    ")\n",
+    "# prompt and generate\n",
+    "prompt = tokenizer(\n",
+    "    \"Once upon a time there was\", return_tensors=\"pt\")\n",
+    "happy_prompt = tokenizer(\n",
+    "    \" Happy\", return_tensors=\"pt\")\n",
+    "_, intervened_story = pv_tinystory.generate(\n",
+    "    prompt, happy_prompt, \n",
+    "    unit_locations = {\"sources->base\": 0},\n",
+    "    max_length=256\n",
     ")\n",
     "\n",
     "print(tokenizer.decode(\n",
@@ -2046,7 +2131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "id": "559bf80a-2a79-46f0-b8a1-8848fd49613b",
    "metadata": {},
    "outputs": [
@@ -2060,7 +2145,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7bc8a51db70643f59c53fe9e7bd22bc0",
+       "model_id": "09c7100d49c94e1b94f3429440f1aab3",
        "version_major": 2,
        "version_minor": 0
       },

--- a/tutorials/advanced_tutorials/Voting_Mechanism.ipynb
+++ b/tutorials/advanced_tutorials/Voting_Mechanism.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "__author__ = \"Zhengxuan Wu and Kevin Du and Tiago Pimentel \"\n",
+    "__author__ = \"Zhengxuan Wu and Kevin Du and Tiago Pimentel\"\n",
     "__version__ = \"02/13/2023\""
    ]
   },
@@ -665,7 +665,7 @@
    "source": [
     "for loc in [78, 75, 80, [75, 80]]:\n",
     "    if loc == 78:\n",
-    "        print(\"[control ]intervening location: \", loc)\n",
+    "        print(\"[control] intervening location: \", loc)\n",
     "        pv_llama.interventions[f'layer.{layer}.comp.block_output.unit.pos.nunit.1#0'][0].load_state_dict(\n",
     "            torch.load('./tutorial_data/layer.15.pos.78.bin'))\n",
     "    else:\n",

--- a/tutorials/advanced_tutorials/Voting_Mechanism.ipynb
+++ b/tutorials/advanced_tutorials/Voting_Mechanism.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": 2,
    "id": "aab5efc5",
    "metadata": {},
    "outputs": [],
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 3,
    "id": "850bf6fd",
    "metadata": {},
    "outputs": [],
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "75d4d2e5",
    "metadata": {},
    "outputs": [
@@ -108,7 +108,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1e586e211b7643709f3d738568ffc730",
+       "model_id": "5e43d3570ec941adb21f8203bbf61b4f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -123,8 +123,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/sailhome/wuzhengx/.local/lib/python3.8/site-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n",
-      "  return self.fget.__get__(instance, owner)()\n"
+      "/sailhome/wuzhengx/.local/lib/python3.8/site-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n"
      ]
     },
     {
@@ -143,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "1499039a",
    "metadata": {},
    "outputs": [],
@@ -166,17 +165,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "fac2e331",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'<s>Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.\\n\\n### Instruction:\\nPlease say yes only if it costs between 3.63 and 7.11 dollars, otherwise no.\\n\\n### Input:\\n8.96 dollars\\n\\n### Response:\\n'"
+       "'<s>Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.\\n\\n### Instruction:\\nPlease say yes only if it costs between 1.60 and 4.11 dollars, otherwise no.\\n\\n### Input:\\n0.32 dollars\\n\\n### Response:\\n'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1243,6 +1242,295 @@
     "#### The results above show if two intervention sites take on contradicting values, it will trust the earlier site. \n",
     "It is hard to say if this would hold till more tests. However, we can see the neural network shows some voting mechanism by trusting some location over another during interventions when these locations take different values. If they have the same value, it seems to working well."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d2deee7",
+   "metadata": {},
+   "source": [
+    "##### Minor: make sure other control models cannot find good alignments\n",
+    "We test this by training Boundless DAS with the best locations in the paper: layer 15 and last token (81th)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e5a9c190",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "control_sampler = bracket_alignment_sampler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5cb5aa40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set_seed(42)\n",
+    "\n",
+    "###################\n",
+    "# data loaders\n",
+    "###################\n",
+    "raw_data = control_sampler(\n",
+    "    tokenizer, 10000,\n",
+    ")\n",
+    "\n",
+    "raw_train = (\n",
+    "    raw_data[0][:8000],\n",
+    "    raw_data[1][:8000],\n",
+    "    raw_data[2][:8000],\n",
+    "    raw_data[3][:8000],\n",
+    ")\n",
+    "raw_eval = (\n",
+    "    raw_data[0][8000:9000],\n",
+    "    raw_data[1][8000:9000],\n",
+    "    raw_data[2][8000:9000],\n",
+    "    raw_data[3][8000:9000],\n",
+    ")\n",
+    "raw_test = (\n",
+    "    raw_data[0][9000:],\n",
+    "    raw_data[1][9000:],\n",
+    "    raw_data[2][9000:],\n",
+    "    raw_data[3][9000:],\n",
+    ")\n",
+    "train_dataset = Dataset.from_dict(\n",
+    "    {\n",
+    "        \"input_ids\": raw_train[0],\n",
+    "        \"source_input_ids\": raw_train[1],\n",
+    "        \"labels\": raw_train[2],\n",
+    "        \"intervention_ids\": raw_train[3],  # we will not use this field\n",
+    "    }\n",
+    ").with_format(\"torch\")\n",
+    "train_dataloader = DataLoader(\n",
+    "    train_dataset,\n",
+    "    batch_size=16,\n",
+    ")\n",
+    "eval_dataset = Dataset.from_dict(\n",
+    "    {\n",
+    "        \"input_ids\": raw_eval[0],\n",
+    "        \"source_input_ids\": raw_eval[1],\n",
+    "        \"labels\": raw_eval[2],\n",
+    "        \"intervention_ids\": raw_eval[3],  # we will not use this field\n",
+    "    }\n",
+    ").with_format(\"torch\")\n",
+    "eval_dataloader = DataLoader(\n",
+    "    eval_dataset,\n",
+    "    batch_size=16,\n",
+    ")\n",
+    "test_dataset = Dataset.from_dict(\n",
+    "    {\n",
+    "        \"input_ids\": raw_test[0],\n",
+    "        \"source_input_ids\": raw_test[1],\n",
+    "        \"labels\": raw_test[2],\n",
+    "        \"intervention_ids\": raw_test[3],  # we will not use this field\n",
+    "    }\n",
+    ").with_format(\"torch\")\n",
+    "test_dataloader = DataLoader(\n",
+    "    test_dataset,\n",
+    "    batch_size=16,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "0f4d8e82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layer = 15\n",
+    "token_position = 81"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "de0d63ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pv_config = pv.IntervenableConfig(\n",
+    "    representations=[\n",
+    "        pv.RepresentationConfig(\n",
+    "            layer, \"block_output\"\n",
+    "        )],\n",
+    "    intervention_types=pv.BoundlessRotatedSpaceIntervention,\n",
+    ")\n",
+    "pv_llama = pv.IntervenableModel(pv_config, llama)\n",
+    "pv_llama.set_device(\"cuda\")\n",
+    "pv_llama.disable_model_gradients()\n",
+    "\n",
+    "epochs = 1\n",
+    "gradient_accumulation_steps = 4\n",
+    "total_step = 0\n",
+    "t_total = int(len(train_dataloader) * epochs)\n",
+    "temperature_start = 50.0\n",
+    "temperature_end = 0.1\n",
+    "temperature_schedule = (\n",
+    "    torch.linspace(\n",
+    "        temperature_start, temperature_end, t_total\n",
+    "    )\n",
+    "    .to(torch.bfloat16)\n",
+    "    .to(\"cuda\")\n",
+    ")\n",
+    "pv_llama.set_temperature(temperature_schedule[total_step])\n",
+    "\n",
+    "warm_up_steps = 0.1 * t_total\n",
+    "optimizer_params = []\n",
+    "for k, v in pv_llama.interventions.items():\n",
+    "    optimizer_params += [\n",
+    "        {\"params\": v[0].rotate_layer.parameters()}]\n",
+    "    optimizer_params += [\n",
+    "        {\"params\": v[0].intervention_boundaries, \"lr\": 1e-2}]\n",
+    "optimizer = torch.optim.Adam(optimizer_params, lr=1e-3)\n",
+    "scheduler = get_linear_schedule_with_warmup(\n",
+    "    optimizer, num_warmup_steps=warm_up_steps,\n",
+    "    num_training_steps=t_total\n",
+    ")\n",
+    "\n",
+    "def calculate_loss(logits, labels):\n",
+    "    shift_logits = logits[..., :, :].contiguous()\n",
+    "    shift_labels = labels[..., :].contiguous()\n",
+    "    # Flatten the tokens\n",
+    "    loss_fct = CrossEntropyLoss()\n",
+    "    shift_logits = shift_logits.view(-1, config.vocab_size)\n",
+    "    shift_labels = shift_labels.view(-1)\n",
+    "    # Enable model parallelism\n",
+    "    shift_labels = shift_labels.to(shift_logits.device)\n",
+    "    loss = loss_fct(shift_logits, shift_labels)\n",
+    "\n",
+    "    for k, v in pv_llama.interventions.items():\n",
+    "        boundary_loss = 1.0 * v[0].intervention_boundaries.sum()\n",
+    "    loss += boundary_loss\n",
+    "\n",
+    "    return loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "8a996118",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "llama trainable parameters:  0\n",
+      "intervention trainable parameters:  16777218\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Epoch: 0: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [13:18<00:00,  1.60s/it, loss=0.73, acc=0.75]\n",
+      "Epoch: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [13:18<00:00, 798.36s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pv_llama.model.train()  # train enables drop-off but no grads\n",
+    "print(\"llama trainable parameters: \", count_parameters(pv_llama.model))\n",
+    "print(\"intervention trainable parameters: \", pv_llama.count_parameters())\n",
+    "train_iterator = trange(0, int(epochs), desc=\"Epoch\")\n",
+    "for epoch in train_iterator:\n",
+    "    epoch_iterator = tqdm(\n",
+    "        train_dataloader, \n",
+    "        desc=f\"Epoch: {epoch}\", position=0, leave=True\n",
+    "    )\n",
+    "    for step, inputs in enumerate(epoch_iterator):\n",
+    "        for k, v in inputs.items():\n",
+    "            if v is not None and isinstance(v, torch.Tensor):\n",
+    "                inputs[k] = v.to(\"cuda\")\n",
+    "        b_s = inputs[\"input_ids\"].shape[0]\n",
+    "        _, counterfactual_outputs = pv_llama(\n",
+    "            {\"input_ids\": inputs[\"input_ids\"]},\n",
+    "            [{\"input_ids\": inputs[\"source_input_ids\"]}],\n",
+    "            {\"sources->base\": token_position},\n",
+    "        )\n",
+    "        eval_metrics = compute_metrics(\n",
+    "            [counterfactual_outputs.logits], [inputs[\"labels\"]]\n",
+    "        )\n",
+    "\n",
+    "        # loss and backprop\n",
+    "        loss = calculate_loss(counterfactual_outputs.logits, inputs[\"labels\"])\n",
+    "        loss_str = round(loss.item(), 2)\n",
+    "        epoch_iterator.set_postfix({\"loss\": loss_str, \"acc\": eval_metrics[\"accuracy\"]})\n",
+    "\n",
+    "        if gradient_accumulation_steps > 1:\n",
+    "            loss = loss / gradient_accumulation_steps\n",
+    "        loss.backward()\n",
+    "        if total_step % gradient_accumulation_steps == 0:\n",
+    "            if not (gradient_accumulation_steps > 1 and total_step == 0):\n",
+    "                optimizer.step()\n",
+    "                scheduler.step()\n",
+    "                optimizer.zero_grad()\n",
+    "                pv_llama.set_temperature(\n",
+    "                    temperature_schedule[total_step])\n",
+    "        total_step += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "32e2894a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Test: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 63/63 [00:43<00:00,  1.46it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'accuracy': 0.68}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# evaluation on the test set\n",
+    "eval_labels = []\n",
+    "eval_preds = []\n",
+    "with torch.no_grad():\n",
+    "    epoch_iterator = tqdm(test_dataloader, desc=f\"Test\")\n",
+    "    for step, inputs in enumerate(epoch_iterator):\n",
+    "        for k, v in inputs.items():\n",
+    "            if v is not None and isinstance(v, torch.Tensor):\n",
+    "                inputs[k] = v.to(\"cuda\")\n",
+    "        b_s = inputs[\"input_ids\"].shape[0]\n",
+    "        _, counterfactual_outputs = pv_llama(\n",
+    "            {\"input_ids\": inputs[\"input_ids\"]},\n",
+    "            [{\"input_ids\": inputs[\"source_input_ids\"]}],\n",
+    "            {\"sources->base\": 75}\n",
+    "        )\n",
+    "        eval_labels += [inputs[\"labels\"]]\n",
+    "        eval_preds += [counterfactual_outputs.logits]\n",
+    "eval_metrics = compute_metrics(eval_preds, eval_labels)\n",
+    "print(eval_metrics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18a61a22",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/advanced_tutorials/tutorial_price_tagging_utils.py
+++ b/tutorials/advanced_tutorials/tutorial_price_tagging_utils.py
@@ -370,3 +370,72 @@ def midpoint_alignment_sampler(
         
     return all_base_input_ids, all_source_input_ids, all_ctf_output_ids, all_intervention_ids
 
+
+def bracket_alignment_sampler(
+    tokenizer,
+    max_n_training_examples,
+    amount=None,
+    lower_bound=None,
+    bound_width=None,
+):
+
+    all_base_input_ids = []
+    all_source_input_ids = []
+    all_ctf_output_ids = [] # this one does not have input ids, etc..
+    all_intervention_ids = []
+    
+    for _ in range(max_n_training_examples):
+        
+        base_lower_bound_sample, base_upper_bound_sample, base_amount_sample = \
+            pricing_tag_game_config_sampler(
+                amount,
+                lower_bound,
+                bound_width
+            )
+        source_lower_bound_sample, source_upper_bound_sample, source_amount_sample = \
+            pricing_tag_game_config_sampler(
+                amount,
+                lower_bound,
+                bound_width
+            )
+        ctf_label = None
+        ctf_label_str = None
+        if base_amount_sample <= source_upper_bound_sample and base_amount_sample >= source_lower_bound_sample:
+            ctf_label = tokenizer.convert_tokens_to_ids("Yes")
+            ctf_label_str = "Yes"
+        else:
+            ctf_label = tokenizer.convert_tokens_to_ids("No")
+            ctf_label_str = "No"
+            
+        base_amount_str = "%.2f dollars" % base_amount_sample
+        source_amount_str = "%.2f dollars" % source_amount_sample
+        base_lower_bound_str = "%.2f" % base_lower_bound_sample
+        base_upper_bound_str = "%.2f" % base_upper_bound_sample
+        source_lower_bound_str = "%.2f" % source_lower_bound_sample
+        source_upper_bound_str = "%.2f" % source_upper_bound_sample
+        
+        # print(f"base: [{base_lower_bound_str}, {base_upper_bound_str}], {base_amount_str}")
+        # print(f"source: [{source_lower_bound_str}, {source_upper_bound_str}], {source_amount_str}")
+        # print(f"ctf label: {ctf_label_str}")
+        
+        base_instruction = f"Please say yes only if it costs between {base_lower_bound_str} and {base_upper_bound_str} dollars, otherwise no."
+        source_instruction = f"Please say yes only if it costs between {source_lower_bound_str} and {source_upper_bound_str} dollars, otherwise no."
+        
+        base_alpaca_prompt = alpaca_prompt_template % (base_instruction, base_amount_str)
+        source_alpaca_prompt = alpaca_prompt_template % (source_instruction, source_amount_str)
+        
+        base_input_ids = tokenizer(base_alpaca_prompt, return_tensors="pt").input_ids[0]
+        source_input_ids = tokenizer(source_alpaca_prompt, return_tensors="pt").input_ids[0]
+        base_input_ids = base_input_ids.tolist()
+        source_input_ids = source_input_ids.tolist()
+        ctf_output_ids = (torch.ones(len(base_input_ids))*-100).long().tolist()
+        ctf_output_ids[-1] = ctf_label
+        
+        all_base_input_ids += [base_input_ids]
+        all_source_input_ids += [source_input_ids]
+        all_ctf_output_ids += [ctf_output_ids]
+        all_intervention_ids += [0]
+        assert len(base_input_ids) == 82
+        assert len(source_input_ids) == 82
+        
+    return all_base_input_ids, all_source_input_ids, all_ctf_output_ids, all_intervention_ids

--- a/tutorials/advanced_tutorials/tutorial_price_tagging_utils.py
+++ b/tutorials/advanced_tutorials/tutorial_price_tagging_utils.py
@@ -296,3 +296,77 @@ def bound_alignment_sampler(
         all_ctf_output_ids,
         all_intervention_ids,
     )
+
+
+def midpoint_alignment_sampler(
+    tokenizer,
+    max_n_training_examples,
+    amount=None,
+    lower_bound=None,
+    bound_width=None,
+):
+
+    all_base_input_ids = []
+    all_source_input_ids = []
+    all_ctf_output_ids = [] # this one does not have input ids, etc..
+    all_intervention_ids = []
+    
+    for _ in range(max_n_training_examples):
+        
+        base_lower_bound_sample, base_upper_bound_sample, base_amount_sample = \
+            pricing_tag_game_config_sampler(
+                amount,
+                lower_bound,
+                bound_width
+            )
+        source_lower_bound_sample, source_upper_bound_sample, source_amount_sample = \
+            pricing_tag_game_config_sampler(
+                amount,
+                lower_bound,
+                bound_width
+            )
+        ctf_label = None
+        ctf_label_str = None
+        source_mid_point = (source_lower_bound_sample+source_upper_bound_sample)/2.0
+        base_half = 0.5*abs(base_upper_bound_sample-base_lower_bound_sample)
+        ctf_mid_diff = abs(base_amount_sample-source_mid_point)
+        if ctf_mid_diff <= base_half:
+            ctf_label = tokenizer.convert_tokens_to_ids("Yes")
+            ctf_label_str = "Yes"
+        else:
+            ctf_label = tokenizer.convert_tokens_to_ids("No")
+            ctf_label_str = "No"
+            
+        base_amount_str = "%.2f dollars" % base_amount_sample
+        source_amount_str = "%.2f dollars" % source_amount_sample
+        base_lower_bound_str = "%.2f" % base_lower_bound_sample
+        base_upper_bound_str = "%.2f" % base_upper_bound_sample
+        source_lower_bound_str = "%.2f" % source_lower_bound_sample
+        source_upper_bound_str = "%.2f" % source_upper_bound_sample
+        
+        # print(f"base: [{base_lower_bound_str}, {base_upper_bound_str}], {base_amount_str}")
+        # print(f"source: [{source_lower_bound_str}, {source_upper_bound_str}], {source_amount_str}")
+        # print(f"ctf label: {ctf_label_str}")
+        
+        base_instruction = f"Please say yes only if it costs between {base_lower_bound_str} and {base_upper_bound_str} dollars, otherwise no."
+        source_instruction = f"Please say yes only if it costs between {source_lower_bound_str} and {source_upper_bound_str} dollars, otherwise no."
+        
+        base_alpaca_prompt = alpaca_prompt_template % (base_instruction, base_amount_str)
+        source_alpaca_prompt = alpaca_prompt_template % (source_instruction, source_amount_str)
+        
+        base_input_ids = tokenizer(base_alpaca_prompt, return_tensors="pt").input_ids[0]
+        source_input_ids = tokenizer(source_alpaca_prompt, return_tensors="pt").input_ids[0]
+        base_input_ids = base_input_ids.tolist()
+        source_input_ids = source_input_ids.tolist()
+        ctf_output_ids = (torch.ones(len(base_input_ids))*-100).long().tolist()
+        ctf_output_ids[-1] = ctf_label
+        
+        all_base_input_ids += [base_input_ids]
+        all_source_input_ids += [source_input_ids]
+        all_ctf_output_ids += [ctf_output_ids]
+        all_intervention_ids += [0]
+        assert len(base_input_ids) == 82
+        assert len(source_input_ids) == 82
+        
+    return all_base_input_ids, all_source_input_ids, all_ctf_output_ids, all_intervention_ids
+


### PR DESCRIPTION
## Description

Fix typos in the voting tutorial. The current intervention calls on generation has a buggy setup if we want to pass in a source and base to do interchange intervention. This is a quick fix but not the final solution.

## Testing Done

Relevant tutorials are reran.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
