### PR TITLE
[Minor] Adding in subspace support for lambda

### DIFF
--- a/pyvene/models/modeling_utils.py
+++ b/pyvene/models/modeling_utils.py
@@ -423,8 +423,11 @@ def do_intervention(
     """Do the actual intervention."""
 
     if isinstance(intervention, types.FunctionType):
-        return intervention(base_representation, source_representation)
-    
+        if subspaces is None:
+            return intervention(base_representation, source_representation)
+        else:
+            return intervention(base_representation, source_representation, subspaces)
+
     num_unit = base_representation.shape[1]
 
     # flatten

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 4,
    "id": "a82664f9",
    "metadata": {},
    "outputs": [
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 5,
    "id": "7627dc32",
    "metadata": {},
    "outputs": [
@@ -347,7 +347,7 @@
        "True"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,6 +368,66 @@
     "# run the intervened forward pass\n",
     "intervened_outputs_fn = pv_gpt2(\n",
     "    base = tokenizer(\"The capital of Spain is\", return_tensors=\"pt\")\n",
+    ")\n",
+    "torch.allclose(\n",
+    "    intervened_outputs[1].last_hidden_state, \n",
+    "    intervened_outputs_fn[1].last_hidden_state\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72363777",
+   "metadata": {},
+   "source": [
+    "#### Set Activation to Zeros with a Lambda Expression and Subspace notation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d86c06f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loaded model\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pyvene as pv\n",
+    "\n",
+    "_, tokenizer, gpt2 = pv.create_gpt2()\n",
+    "\n",
+    "# indices are specified in the intervention\n",
+    "\n",
+    "def pv_patcher(b, s, sp): \n",
+    "    mask = torch.ones(1, 5, 768)\n",
+    "    mask[:,sp[0][0],:] = 0.\n",
+    "    return b*mask\n",
+    "\n",
+    "# define the component to zero-out\n",
+    "pv_gpt2 = pv.IntervenableModel({\n",
+    "    \"component\": \"h[0].mlp.output\", \"intervention\": pv_patcher\n",
+    "}, model=gpt2)\n",
+    "# run the intervened forward pass\n",
+    "intervened_outputs_fn = pv_gpt2(\n",
+    "    base = tokenizer(\"The capital of Spain is\", return_tensors=\"pt\"),\n",
+    "    subspaces=3,\n",
     ")\n",
     "torch.allclose(\n",
     "    intervened_outputs[1].last_hidden_state, \n",


### PR DESCRIPTION
## Description

Currently, the code assumes whenever we use customized function or lambda expression based interventions, we only allow two arguments. This. change allows us to specify the subspace for these interventions as well.

Ideally, the third argument could be anything for these customized interventions, which will be a future change.

## Testing Done

Tutorial test is added.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
