### PR TITLE
[P1] Disable base output by default in fwd() and gen()

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -1247,7 +1247,7 @@ class IntervenableModel(nn.Module):
         unit_locations: Optional[Dict] = None,
         source_representations: Optional[Dict] = None,
         subspaces: Optional[List] = None,
-        output_original_output: Optional[bool] = None,
+        output_original_output: Optional[bool] = False,
         return_dict: Optional[bool] = None,
     ):
         """
@@ -1340,9 +1340,11 @@ class IntervenableModel(nn.Module):
             activations_sources,
             subspaces,
         )
-
-        # returning un-intervened output with gradients
-        base_outputs = self.model(**base)
+        
+        base_outputs = None
+        if output_original_output:
+            # returning un-intervened output with gradients
+            base_outputs = self.model(**base)
 
         try:
             # intervene
@@ -1416,6 +1418,7 @@ class IntervenableModel(nn.Module):
         source_representations: Optional[Dict] = None,
         intervene_on_prompt: bool = False,
         subspaces: Optional[List] = None,
+        output_original_output: Optional[bool] = False,
         **kwargs,
     ):
         """
@@ -1471,9 +1474,11 @@ class IntervenableModel(nn.Module):
             activations_sources,
             subspaces,
         )
-
-        # returning un-intervened output
-        base_outputs = self.model.generate(inputs=base["input_ids"], **kwargs)
+        
+        base_outputs = None
+        if output_original_output:
+            # returning un-intervened output
+            base_outputs = self.model.generate(inputs=base["input_ids"], **kwargs)
 
         set_handlers_to_remove = None
         try:

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -316,7 +316,8 @@
     "intervened_outputs = pv_gpt2(\n",
     "    base = tokenizer(\"The capital of Spain is\", return_tensors=\"pt\"), \n",
     "    # we define the intervening token dynamically\n",
-    "    unit_locations={\"base\": 3}\n",
+    "    unit_locations={\"base\": 3},\n",
+    "    output_original_output=True # False then the first element in the tuple is None\n",
     ")"
    ]
   },
@@ -1067,7 +1068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "f718e2d6",
    "metadata": {},
    "outputs": [
@@ -1075,6 +1076,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/sailhome/wuzhengx/.local/lib/python3.8/site-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n",
+      "  return self.fget.__get__(instance, owner)()\n",
       "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
       "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n"
      ]
@@ -1083,21 +1086,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "loaded model\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
-      "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "loaded model\n",
       "Once upon a time there was a little girl named Lucy. She was three years old and loved to explore. One day, Lucy was walking in the park when she saw a big, red balloon. She was so excited and wanted to play with it.\n",
       "\n",
       "But then, a big, mean man came and said, \"That balloon is mine! You can't have it!\" Lucy was very sad and started to cry.\n",
@@ -1138,7 +1127,7 @@
     "# prompt and generate\n",
     "prompt = tokenizer(\n",
     "    \"Once upon a time there was\", return_tensors=\"pt\")\n",
-    "_, intervened_story = pv_tinystory.generate(\n",
+    "unintervened_story, intervened_story = pv_tinystory.generate(\n",
     "    prompt, source_representations=emb_happy*0.3, max_length=256\n",
     ")\n",
     "\n",

--- a/tests/integration_tests/ComplexInterventionWithGPT2TestCase.py
+++ b/tests/integration_tests/ComplexInterventionWithGPT2TestCase.py
@@ -62,7 +62,7 @@ class ComplexInterventionWithGPT2TestCase(unittest.TestCase):
         intervenable.set_device(self.device)
         base = {"input_ids": torch.randint(0, 10, (10, 5)).to(self.device)}
         golden_out = self.gpt2(**base).logits
-        our_output = intervenable(base)[0][0]
+        our_output = intervenable(base, output_original_output=True)[0][0]
         self.assertTrue(torch.allclose(golden_out, our_output))
         # make sure the toolkit also works
         self.assertTrue(

--- a/tests/integration_tests/InterventionWithMLPTestCase.py
+++ b/tests/integration_tests/InterventionWithMLPTestCase.py
@@ -112,7 +112,8 @@ class InterventionWithMLPTestCase(unittest.TestCase):
         )
         base = {"inputs_embeds": torch.rand(10, 1, 3)}
         self.assertTrue(
-            torch.allclose(ONE_MLP_CLEAN_RUN(base, self.mlp), intervenable(base)[0][0])
+            torch.allclose(ONE_MLP_CLEAN_RUN(base, self.mlp), intervenable(
+                base, output_original_output=True)[0][0])
         )
 
     def test_with_subspace_positive(self):

--- a/tests/integration_tests/InterventionWithMLPTestCase.py
+++ b/tests/integration_tests/InterventionWithMLPTestCase.py
@@ -255,6 +255,7 @@ class InterventionWithMLPTestCase(unittest.TestCase):
             [source_1, source_2],
             {"sources->base": ([[[0]] * b_s, [[0]] * b_s], [[[0]] * b_s, [[0]] * b_s])},
             subspaces=[[[0]] * b_s, [[1]] * b_s],
+            output_original_output=True,
         )
 
         self.assertTrue(torch.allclose(golden_out_inplace, our_out_inplace[0]))


### PR DESCRIPTION
## Description

The `forward()` and `generate()` call by default returns the output of unintervened model. This could cause slow down during training and inference. We disable them by default.

## Testing Done

notebook is updated.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
