### PR TITLE
[P0] Rename train/evaluate methods so train/eval can set model state

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The function solves a 3-digit sum problem. Let's say, we trained a neural networ
 
 To translate the above steps into API calls with the library, it will be a single call,
 ```py
-intervenable.evaluate(
+intervenable.eval_alignment(
     train_dataloader=test_dataloader,
     compute_metrics=compute_metrics,
     inputs_collator=inputs_collator
@@ -232,7 +232,7 @@ Instead of activation swapping in the original representation space, we first **
 
 You can now also make a single API call to train your intervention,
 ```py
-intervenable.train(
+intervenable.train_alignment(
     train_dataloader=train_dataloader,
     compute_loss=compute_loss,
     compute_metrics=compute_metrics,

--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -1640,8 +1640,14 @@ class IntervenableModel(nn.Module):
                 )
 
         return batched_location_dict
+    
+    def train(self):
+        self.model.train()
+    
+    def eval(self):
+        self.model.eval()
 
-    def train(
+    def train_alignment(
         self,
         train_dataloader,
         compute_loss,
@@ -1732,7 +1738,7 @@ class IntervenableModel(nn.Module):
                         self.set_temperature(temperature_schedule[total_step])
                 total_step += 1
 
-    def evaluate(
+    def eval_alignment(
         self,
         eval_dataloader,
         compute_metrics,

--- a/pyvene/models/llama/modelings_intervenable_llama.py
+++ b/pyvene/models/llama/modelings_intervenable_llama.py
@@ -61,7 +61,7 @@ llama_lm_type_to_dimension_mapping = llama_type_to_dimension_mapping
 
 
 def create_llama(
-    name="sharpbai/alpaca-7b-merged", cache_dir=None
+    name="sharpbai/alpaca-7b-merged", cache_dir=None, dtype=torch.bfloat16
 ):
     """Creates a LLaMA Causal LM model, config, and tokenizer from the given name and revision"""
     from transformers import LlamaForCausalLM, LlamaTokenizer, LlamaConfig
@@ -72,7 +72,7 @@ def create_llama(
         name,
         config=config,
         cache_dir=cache_dir,
-        torch_dtype=torch.bfloat16,  # save memory
+        torch_dtype=dtype,  # save memory
     )
     print("loaded model")
     return config, tokenizer, llama

--- a/tutorials/basic_tutorials/Intervention_Training.ipynb
+++ b/tutorials/basic_tutorials/Intervention_Training.ipynb
@@ -1087,7 +1087,7 @@
     }
    ],
    "source": [
-    "intervenable.train(\n",
+    "intervenable.train_alignment(\n",
     "    train_dataloader=train_dataloader,\n",
     "    compute_loss=compute_loss,\n",
     "    compute_metrics=compute_metrics,\n",
@@ -1128,7 +1128,7 @@
     }
    ],
    "source": [
-    "intervenable.evaluate(\n",
+    "intervenable.eval_alignment(\n",
     "    eval_dataloader=test_dataloader,\n",
     "    compute_metrics=compute_metrics,\n",
     "    inputs_collator=inputs_collator,\n",


### PR DESCRIPTION
## Description

Currently `IntervenableModel.train()` and `IntervenableModel.evaluate()` are helper methods for training and evaluating interventions in a simple interface. I am renaming these to `train_alignment()` and `eval_alignment()` so that `train()` and `eval()` can set the model state (so that HF trainer can be compatible with this interface).

I think we have not actually been using these in `pyvene`-based projects because they don't allow much customisation so this doesn't break much; just had to change one notebook.

## Testing Done

Tested in current project and worked. Let's see if tests pass!

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
