### PR TITLE
[Minor] Allow other field passing in generate besides input_ids

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -1496,7 +1496,7 @@ class IntervenableModel(nn.Module):
         base_outputs = None
         if output_original_output:
             # returning un-intervened output
-            base_outputs = self.model.generate(inputs=base["input_ids"], **kwargs)
+            base_outputs = self.model.generate(**base, **kwargs)
 
         set_handlers_to_remove = None
         try:
@@ -1522,7 +1522,7 @@ class IntervenableModel(nn.Module):
             
             # run intervened generate
             counterfactual_outputs = self.model.generate(
-                inputs=base["input_ids"], **kwargs
+                **base, **kwargs
             )
             
             collected_activations = []

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -139,6 +139,7 @@
     }
    ],
    "source": [
+    "import torch\n",
     "import pyvene as pv\n",
     "\n",
     "_, tokenizer, gpt2 = pv.create_gpt2()\n",
@@ -222,6 +223,7 @@
     }
    ],
    "source": [
+    "import torch\n",
     "import pyvene as pv\n",
     "\n",
     "_, tokenizer, gpt2 = pv.create_gpt2()\n",
@@ -262,6 +264,7 @@
     }
    ],
    "source": [
+    "import torch\n",
     "import copy\n",
     "import pyvene as pv\n",
     "\n",
@@ -1068,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "f718e2d6",
    "metadata": {},
    "outputs": [
@@ -1076,9 +1079,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/sailhome/wuzhengx/.local/lib/python3.8/site-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n",
-      "  return self.fget.__get__(instance, owner)()\n",
-      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
       "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n"
      ]
     },
@@ -2647,7 +2647,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.13"
   },
   "toc-autonumbering": true,
   "toc-showcode": false,


### PR DESCRIPTION
## Description

In `generate()` call, we only pass in the `input_ids` field and rely on huggingface module to populate the attention mask fields. We now pass in the whole user input dict instead.

## Testing Done

Tutorial test run passed.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [ ] I have added tests for my changes
