### PR TITLE
[Minor] Revert CausalModel to accept input/output functions when generating factual/counterfactual datasets 

### DIFF
--- a/pyvene/data_generators/causal_model.py
+++ b/pyvene/data_generators/causal_model.py
@@ -309,10 +309,17 @@ class CausalModel:
         sampler=None,
         filter=None,
         device="cpu",
+        input_function=None,
+        output_function=None,
         return_tensors=True,
     ):
         if sampler is None:
             sampler = self.sample_input
+        
+        if input_function is None:
+            input_function = self.input_to_tensor
+        if output_function is None:
+            output_function = self.output_to_tensor
 
         examples = []
         while len(examples) < size:
@@ -321,8 +328,8 @@ class CausalModel:
             if filter is None or filter(input):
                 output = self.run_forward(input)
                 if return_tensors:
-                    example['input_ids'] = self.input_to_tensor(input).to(device)
-                    example['labels'] = self.output_to_tensor(output).to(device)
+                    example['input_ids'] = input_function(input).to(device)
+                    example['labels'] = output_function(output).to(device)
                 else:
                     example['input_ids'] = input
                     example['labels'] = output
@@ -339,8 +346,15 @@ class CausalModel:
         intervention_sampler=None,
         filter=None,
         device="cpu",
+        input_function=None,
+        output_function=None,
         return_tensors=True,
     ):
+        if input_function is None:
+            input_function = self.input_to_tensor
+        if output_function is None:
+            output_function = self.output_to_tensor
+
         maxlength = len(
             [
                 var

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt', 'r', encoding='utf-8') as f:
 
 setup(
     name="pyvene",
-    version="0.0.8",
+    version="0.0.9dev",
     description="Use Activation Intervention to Interpret Causal Mechanism of Model",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Description

Small change that re-introduces input & output functions for pre-processing data when generating datasets from the causal model.
Only the `causal_model.py` file was edited.

## Testing Done

Ran test cases for causal model (see screenshot below). Other tests aren't necessary because they aren't affected by `causal_model.py`. 
Tutorials using causal model run as expected since the update doesn't change the code's old behavior.

<img width="402" alt="image" src="https://github.com/stanfordnlp/pyvene/assets/81783761/915ede9a-7647-46c8-90a0-829f8c980a8f">