### PR TITLE
[P0] make sure config only has strs

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -47,7 +47,7 @@ class IntervenableModel(nn.Module):
         self.mode = config.mode
         intervention_type = config.intervention_types
         self.is_model_stateless = is_stateless(model)
-        self.config.model_type = type(model) # backfill
+        self.config.model_type = str(type(model)) # backfill
         self.use_fast = kwargs["use_fast"] if "use_fast" in kwargs else False
 
         self.model_has_grad = False


### PR DESCRIPTION
## Description

Stored model type as `str` in the config dict. Necessary for `transformers` train loop checks.

## Testing Done

Should have no effect on functionality.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [ ] I have attached the testing log above
- [ ] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
