### PR TITLE
[Minor] Adding `use_cache` flag to intervenable model forward call

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -1440,10 +1440,14 @@ class IntervenableModel(nn.Module):
                 )
 
             # run intervened forward
-            if labels is not None:
-                counterfactual_outputs = self.model(**base, labels=labels, use_cache=use_cache)
-            else:
-                counterfactual_outputs = self.model(**base, use_cache=use_cache)
+            model_kwargs = {}
+            if labels is not None: # for training
+                model_kwargs["labels"] = labels
+            if 'use_cache' in self.model.config.to_dict(): # for transformer models
+                model_kwargs["use_cache"] = use_cache
+
+            counterfactual_outputs = self.model(**base, **model_kwargs)
+
             set_handlers_to_remove.remove()
 
             self._output_validation()

--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -1320,6 +1320,7 @@ class IntervenableModel(nn.Module):
         labels: Optional[torch.LongTensor] = None,
         output_original_output: Optional[bool] = False,
         return_dict: Optional[bool] = None,
+        use_cache: Optional[bool] = True,
     ):
         """
         Main forward function that serves a wrapper to
@@ -1440,9 +1441,9 @@ class IntervenableModel(nn.Module):
 
             # run intervened forward
             if labels is not None:
-                counterfactual_outputs = self.model(**base, labels=labels)
+                counterfactual_outputs = self.model(**base, labels=labels, use_cache=use_cache)
             else:
-                counterfactual_outputs = self.model(**base)
+                counterfactual_outputs = self.model(**base, use_cache=use_cache)
             set_handlers_to_remove.remove()
 
             self._output_validation()


### PR DESCRIPTION
## Description

Added `use_cache` flag to forward call in `IntervenableModel`. This is necessary for DPO training with ReFT.

## Testing Done

Ran all unit tests successfully. Logs attached below.
[unittest_logs.txt](https://github.com/stanfordnlp/pyvene/files/15181365/unittest_logs.txt)

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
