### PR TITLE
[P2] Save/load trainable params in `IntervenableBase` methods

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -418,7 +418,7 @@ class IntervenableModel(nn.Module):
     
     def save(
         self, save_directory, save_to_hf_hub=False, hf_repo_name="my-awesome-model",
-        include_model=True
+        include_model=False
     ):
         """
         Save interventions to disk or hub
@@ -526,7 +526,7 @@ class IntervenableModel(nn.Module):
     @staticmethod
     def load(
         load_directory, model, local_directory=None, from_huggingface_hub=False,
-        include_model=True
+        include_model=False
     ):
         """
         Load interventions from disk or hub

--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -416,7 +416,8 @@ class IntervenableModel(nn.Module):
                 v[0].zero_grad()
     
     def save(
-        self, save_directory, save_to_hf_hub=False, hf_repo_name="my-awesome-model"
+        self, save_directory, save_to_hf_hub=False, hf_repo_name="my-awesome-model",
+        include_model=True
     ):
         """
         Save interventions to disk or hub
@@ -493,6 +494,15 @@ class IntervenableModel(nn.Module):
             else:
                 saving_config.intervention_dimensions += [intervention.interchange_dim.tolist()]
             saving_config.intervention_constant_sources += [intervention.is_source_constant]
+
+        # save model's trainable parameters as well
+        if include_model:
+            model_state_dict = {}
+            model_binary_filename = "pytorch_model.bin"
+            for n, p in self.model.named_parameters():
+                if p.requires_grad:
+                    model_state_dict[n] = p
+            torch.save(model_state_dict, os.path.join(save_directory, model_binary_filename))
             
         # save metadata config
         saving_config.save_pretrained(save_directory)
@@ -513,7 +523,10 @@ class IntervenableModel(nn.Module):
             )
 
     @staticmethod
-    def load(load_directory, model, local_directory=None, from_huggingface_hub=False):
+    def load(
+        load_directory, model, local_directory=None, from_huggingface_hub=False,
+        include_model=True
+    ):
         """
         Load interventions from disk or hub
         """
@@ -566,6 +579,12 @@ class IntervenableModel(nn.Module):
             elif isinstance(intervention, TrainableIntervention):
                 saved_state_dict = torch.load(os.path.join(load_directory, binary_filename))
                 intervention.load_state_dict(saved_state_dict)
+
+        # load model's trainable parameters as well
+        if include_model:
+            model_binary_filename = "pytorch_model.bin"
+            saved_model_state_dict = torch.load(os.path.join(load_directory, model_binary_filename))
+            intervenable.model.load_state_dict(saved_model_state_dict, strict=False)
 
         return intervenable
 


### PR DESCRIPTION
## Description

Add saving/loading of trainable parameters in the model (e.g. classification heads) to `IntervenableModel.save()` and `IntervenableModel.load()`. Draft PR since some tests are failing, will finalise tomorrow.

## Testing Done

Saving/loading of Gemma 2B-IT for sequence classification works perfectly.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
