### PR TITLE
[P0] Revert back the kwargs argument for intervention init

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -122,7 +122,7 @@ class IntervenableModel(nn.Module):
                 all_metadata["embed_dim"] = component_dim
                 all_metadata["use_fast"] = self.use_fast
                 intervention = intervention_function(
-                    **all_metadata, **kwargs
+                    **all_metadata
                 )
                 
             if representation.intervention_link_key in self._intervention_pointers:

--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -122,7 +122,7 @@ class IntervenableModel(nn.Module):
                 all_metadata["embed_dim"] = component_dim
                 all_metadata["use_fast"] = self.use_fast
                 intervention = intervention_function(
-                    **all_metadata
+                    **all_metadata, **kwargs
                 )
                 
             if representation.intervention_link_key in self._intervention_pointers:

--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -129,7 +129,16 @@
    "execution_count": 2,
    "id": "17c7f2f6-b0d3-4fe2-8e4f-c044b93f3ef0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/u/nlp/anaconda/main/anaconda3/envs/wuzhengx-310/lib/python3.10/site-packages/transformers/utils/hub.py:124: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "import pyvene as pv\n",
     "from transformers import AutoTokenizer, AutoModelForCausalLM\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ protobuf>=3.20.0
 matplotlib>=3.7.4
 ipywidgets>=8.1.1
 plotnine>=0.12.4
-huggingface-hub==0.20.3
+huggingface-hub==0.23.4
 numpy>=1.23.5
 fsspec>=2023.6.0
 accelerate>=0.26.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 torch>=2.0.0
-transformers>=4.38.1
+transformers==4.40.2
 datasets>=2.16.1
 protobuf>=3.20.0
 matplotlib>=3.7.4
 ipywidgets>=8.1.1
 plotnine>=0.12.4
-huggingface-hub==0.23.4
+huggingface-hub==0.20.3
 numpy>=1.23.5
 fsspec>=2023.6.0
 accelerate>=0.26.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ protobuf>=3.20.0
 matplotlib>=3.7.4
 ipywidgets>=8.1.1
 plotnine>=0.12.4
-huggingface-hub==0.20.3
+huggingface-hub==0.22.0
 numpy>=1.23.5
 fsspec>=2023.6.0
 accelerate>=0.29.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ plotnine>=0.12.4
 huggingface-hub==0.20.3
 numpy>=1.23.5
 fsspec>=2023.6.0
-accelerate>=0.26.1
+accelerate>=0.29.1
 sentencepiece>=0.1.96


### PR DESCRIPTION
## Description

Recent SAE change causes a regression for some existing tests. This change tries to fix the issue by reverting back some code change.

## Testing Done

Running existing tests.

## Checklist:

- [X] My PR title strictly follows the format: `[Your Priority] Your Title`
- [X] I have attached the testing log above
- [X] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
