### PR TITLE
device of unit_locations should follow tensor_input

### DIFF
--- a/pyvene/models/modeling_utils.py
+++ b/pyvene/models/modeling_utils.py
@@ -293,7 +293,7 @@ def gather_neurons(tensor_input, unit, unit_locations_as_list, device=None):
         return tensor_output  # b, num_unit (h), num_unit (pos), d
     else:
         unit_locations = torch.tensor(
-            unit_locations_as_list, device="cpu"
+            unit_locations_as_list, device=tensor_input.device if device is None else device
         )
 
         tensor_output = torch.gather(


### PR DESCRIPTION
## Description

In `modeling_utils.py`, there is a part of the code that causes error when using GPU. It seems that it's because the `unit_locations` variable was forced to be in cpu.

## Testing Done

No test done yet, just to flag the issue and to raise the attention of the main contributors

## Checklist:

- [ ] My PR title strictly follows the format: `[Your Priority] Your Title`
- [ ] I have attached the testing log above
- [ ] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
