### PR TITLE
add support for dict outputs (select the first value)

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -461,6 +461,8 @@ class BaseModel(nn.Module):
             # data structure casting
             if isinstance(output, tuple):
                 original_output = output[0].clone()
+            elif isinstance(output, dict):
+                original_output = output[list(output.keys())[0]].clone()
             else:
                 original_output = output.clone()
             # for non-sequence models, there is no concept of
@@ -502,6 +504,8 @@ class BaseModel(nn.Module):
         # data structure casting
         if isinstance(output, tuple):
             original_output = output[0]
+        elif isinstance(output, dict):
+            original_output = output[list(output.keys())[0]]
         else:
             original_output = output
         # for non-sequence-based models, we simply replace


### PR DESCRIPTION
## Description

Add simple (and naive) for dictionary output of modules. Similar to how `tuples`s were dealt with, I just select the first value of the dict. Only made changes to `BaseModel`. I'm not yet super familiar with the code so there might be some other modification needed.

## Testing Done

It works with my model which has module dict outputs (for ZeroIntervention and LoreftIntervention). Didn't do extensive testing as this felt quite straightforward.

## Checklist: 

- [ ] My PR title strictly follows the format: `[Your Priority] Your Title`
- [ ] I have attached the testing log above
- [ ] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
