### PR TITLE
[Minor] Update the huggingface-hub version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ protobuf>=3.20.0
 matplotlib>=3.7.4
 ipywidgets>=8.1.1
 plotnine>=0.12.4
-huggingface-hub==0.22.0
+huggingface-hub>=0.24.0
 numpy>=1.23.5
 fsspec>=2023.6.0
 accelerate>=0.29.1


### PR DESCRIPTION
## Description

Updating the version to avoid the following error:

```
RuntimeError: Failed to import transformers.models.blip.modeling_blip because of the following error (look up to see its traceback):
Failed to import transformers.generation.utils because of the following error (look up to see its traceback):
cannot import name 'split_torch_state_dict_into_shards' from 'huggingface_hub' (/usr/local/lib/python3.10/site-packages/huggingface_hub/__init__.py)
```

## Testing Done

[Describe Your Changes Here ...]

## Checklist:

- [ ] My PR title strictly follows the format: `[Your Priority] Your Title`
- [ ] I have attached the testing log above
- [ ] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
