### PR TITLE
fix module usage guide

### DIFF
--- a/pyvene_101.ipynb
+++ b/pyvene_101.ipynb
@@ -2598,7 +2598,7 @@
     "    model=resnet\n",
     ")\n",
     "intervened_outputs = pv_resnet(\n",
-    "    base_inputs, [source_inputs], return_dict=True\n",
+    "    base_inputs, [source_inputs], output_original_output = True, return_dict=True\n",
     ")\n",
     "(intervened_outputs.intervened_outputs.logits - intervened_outputs.original_outputs.logits).sum()"
    ]
@@ -2655,7 +2655,7 @@
     ")\n",
     "\n",
     "intervened_outputs = pv_resnet(\n",
-    "    base_inputs, [source_inputs], return_dict=True\n",
+    "    base_inputs, [source_inputs], output_original_output = True, return_dict=True\n",
     ")\n",
     "(intervened_outputs.intervened_outputs.logits - intervened_outputs.original_outputs.logits).sum()"
    ]


### PR DESCRIPTION
## [Minor] Documentation Fix for Enabling the parameter `output_original_output`

## Description

The `IntervenableModel` class requires the `output_original_output` boolean flag to be enabled for the code to function as expected. Not passing this parameter in the Jupyter notebook while intervening on ResNet models results in an empty dictionary for original outputs. Consequently, attempting to compute the difference between the intervened output and the original output raises the following error: 

```AttributeError: 'NoneType' object has no attribute 'logits'```

## Testing Done

The code was tested by including the parameter `output_original_output=True`. This change allowed for the correct computation of outputs without errors and the html build was verified accordingly. 

This could however be changed to making the default value set to `True` when defining these functions in the `intervenable_base` module but these might be broader design choices. The same changes could possible result in erroring out in other blocks for different model architecture if the difference is computed but I haven't tested that.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [x] I have attached the testing log above
- [x] I provide enough comments to my code
- [x] I have changed documentations
- [x] I have added tests for my changes
