### PR TITLE
[Minor] Migrate to `logger.warning` usage

### DIFF
--- a/pyvene/models/intervenable_base.py
+++ b/pyvene/models/intervenable_base.py
@@ -63,13 +63,13 @@ class BaseModel(nn.Module):
         # if as_adaptor is turn on, we pass in the input args to the intervention
         self.as_adaptor = kwargs["as_adaptor"] if "as_adaptor" in kwargs else False
         if self.as_adaptor:
-            logging.warn(
+            logging.warning(
                 "as_adaptor is turned on. This means the intervention will take "
                 "the input arguments of the intervening module as well."
             )
         self.model_has_grad = False
         if self.use_fast:
-            logging.warn(
+            logging.warning(
                 "Detected use_fast=True means the intervention location "
                 "will be static within a batch.\n\nIn case multiple "
                 "location tags are passed only the first one will "
@@ -184,7 +184,7 @@ class BaseModel(nn.Module):
             if representation.group_key is not None:
                 _any_group_key = True
         if self.config.sorted_keys is not None:
-            logging.warn(
+            logging.warning(
                 "The key is provided in the config. "
                 "Assuming this is loaded from a pretrained module."
             )
@@ -1879,7 +1879,7 @@ class IntervenableModel(BaseModel):
         actual model forward calls. It will use forward
         hooks to do interventions.
 
-        In essense, sources will lead to getter hooks to
+        In essence, sources will lead to getter hooks to
         get activations. We will use these activations to
         intervene on our base example.
 
@@ -1919,7 +1919,7 @@ class IntervenableModel(BaseModel):
         subspaces is a list of indices indicating which subspace will
         this intervention target given an example in the batch.
 
-        An intervention could be initialized with subspace parition as,
+        An intervention could be initialized with subspace partition as,
         [[... subspace_1 ...], [... subspace_2 ...], [rest]]
 
         An intervention may be targeting a specific partition.
@@ -1933,7 +1933,7 @@ class IntervenableModel(BaseModel):
 
         Only setter (where do_intervention is called) needs this field.
 
-        *We assume base and source targetting the same subspace for now.
+        *We assume base and source targeting the same subspace for now.
         *We assume only a single space is targeted for now (although 2d list is provided).
 
         Since we now support group-based intervention, the number of sources
@@ -2182,7 +2182,7 @@ class IntervenableModel(BaseModel):
         Each location list in the raw input as,
 
         [[i, j, ...], [m, n, ...], ...] batched
-        where i, j are the unit index, the outter
+        where i, j are the unit index, the outer
         list is for the batch
 
 


### PR DESCRIPTION
## Description
The `logger.warn` method is deprecated so the library throws different deprecation warning: 
```python
/home/runner/work/pyvene/pyvene/pyvene/models/intervenable_base.py:72: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.

## Testing Done
Run tests.

## Checklist:

- [x] My PR title strictly follows the format: `[Your Priority] Your Title`
- [ ] I have attached the testing log above
- [ ] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
