### PR TITLE
fix attention in qwen model

### DIFF
--- a/pyvene/models/qwen2/modelings_intervenable_qwen2.py
+++ b/pyvene/models/qwen2/modelings_intervenable_qwen2.py
@@ -36,15 +36,15 @@ qwen2_type_to_dimension_mapping = {
     "mlp_output": ("hidden_size",),
     "mlp_input": ("hidden_size",),
     "attention_value_output": ("hidden_size",),
-    "head_attention_value_output": ("head_dim",),
+    "head_attention_value_output": ("hidden_size/num_attention_heads",),
     "attention_output": ("hidden_size",),
     "attention_input": ("hidden_size",),
     "query_output": ("hidden_size",),
     "key_output": ("hidden_size",),
     "value_output": ("hidden_size",),
-    "head_query_output": ("head_dim",),
-    "head_key_output": ("head_dim",),
-    "head_value_output": ("head_dim",),
+    "head_query_output": ("hidden_size/num_attention_heads",),
+    "head_key_output": ("hidden_size/num_attention_heads",),
+    "head_value_output": ("hidden_size/num_attention_heads",),
 }
 
 """qwen2 model with LM head"""


### PR DESCRIPTION
## Description

A quick bugfix where the qwen file referenced "head_dim" which does not exist and is now replaced with "num_attention_heads/hidden_size"

## Testing Done

This allowed my pyvene code with qwen to work

## Checklist:

- [ ] My PR title strictly follows the format: `[Your Priority] Your Title`
- [ ] I have attached the testing log above
- [ ] I provide enough comments to my code
- [ ] I have changed documentations
- [ ] I have added tests for my changes
