### PR TITLE
Add DataCollatorForIntervention for padding base and source inputs

### DIFF
--- a/pyvene/__init__.py
+++ b/pyvene/__init__.py
@@ -40,6 +40,7 @@ from .models.interventions import InterventionOutput
 
 # Utils
 from .models.basic_utils import *
+from .models.data_collator import DataCollatorForIntervention
 from .models.intervention_utils import _do_intervention_by_swap
 from .models.intervenable_modelcard import (
     type_to_module_mapping,

--- a/pyvene/models/data_collator.py
+++ b/pyvene/models/data_collator.py
@@ -113,13 +113,23 @@ class DataCollatorForIntervention:
         )
 
         if labels is not None:
-            max_label_length = max(len(label) for label in labels)
-            if self.pad_to_multiple_of is not None:
-                max_label_length = (
-                    (max_label_length + self.pad_to_multiple_of - 1)
-                    // self.pad_to_multiple_of
-                    * self.pad_to_multiple_of
-                )
+            # When the caller requests ``padding="max_length"`` with a
+            # ``max_length``, ``tokenizer.pad`` pads ``input_ids`` out to that
+            # length, so the labels have to match it. Otherwise pad to the
+            # longest label in the batch, mirroring ``DataCollatorForSeq2Seq``.
+            if (
+                self.padding in ("max_length", PaddingStrategy.MAX_LENGTH)
+                and self.max_length is not None
+            ):
+                max_label_length = self.max_length
+            else:
+                max_label_length = max(len(label) for label in labels)
+                if self.pad_to_multiple_of is not None:
+                    max_label_length = (
+                        (max_label_length + self.pad_to_multiple_of - 1)
+                        // self.pad_to_multiple_of
+                        * self.pad_to_multiple_of
+                    )
 
             padding_side = self.tokenizer.padding_side
             padded_labels = []

--- a/pyvene/models/data_collator.py
+++ b/pyvene/models/data_collator.py
@@ -1,0 +1,137 @@
+"""
+Data collators for working with pyvene models.
+
+Interchange interventions train on examples that carry two sets of inputs at
+once. A base example contributes ``input_ids`` and ``attention_mask`` while the
+source example contributes ``source_input_ids`` and ``source_attention_mask``.
+The two sets usually have different lengths, so a single collator has to pad
+both of them to their own per batch maximum.
+
+Hugging Face ships ``DataCollatorForSeq2Seq``, which pads ``input_ids``,
+``attention_mask`` and ``labels`` but leaves the source keys untouched. The
+collator below mirrors that base behaviour and adds matching padding for the
+source set so that a pyvene dataloader produces rectangular tensors for both
+sides of an intervention.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+from transformers.utils import PaddingStrategy
+
+
+@dataclass
+class DataCollatorForIntervention:
+    """Collate batches that carry both base and source inputs for pyvene.
+
+    The collator pads the base set (``input_ids`` and ``attention_mask``) and
+    the source set (``source_input_ids`` and ``source_attention_mask``) to their
+    own per batch maximum length, padding each independently the way
+    ``DataCollatorForSeq2Seq`` pads the base set. When ``labels`` are present
+    they are padded with ``label_pad_token_id`` on the same side the tokenizer
+    pads. Any other key is stacked through the tokenizer as usual.
+
+    Args:
+        tokenizer: the tokenizer used to encode the data. It supplies the pad
+            token id and the padding side.
+        padding: passed straight to ``tokenizer.pad``. ``True`` or ``"longest"``
+            pads to the per batch maximum.
+        max_length: optional cap on the padded length.
+        pad_to_multiple_of: pad the sequence to a multiple of this value.
+        label_pad_token_id: id used to pad ``labels`` so the loss can ignore it.
+        return_tensors: tensor type returned by the tokenizer, ``"pt"`` for
+            PyTorch tensors.
+    """
+
+    tokenizer: PreTrainedTokenizerBase
+    padding: Union[bool, str, PaddingStrategy] = True
+    max_length: Optional[int] = None
+    pad_to_multiple_of: Optional[int] = None
+    label_pad_token_id: int = -100
+    return_tensors: str = "pt"
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        # Pull the source keys out so the base set can be padded on its own,
+        # then strip the "source_" prefix and pad that set the same way.
+        source_features = []
+        for feature in features:
+            source_feature = {}
+            if "source_input_ids" in feature:
+                source_feature["input_ids"] = feature["source_input_ids"]
+            if "source_attention_mask" in feature:
+                source_feature["attention_mask"] = feature["source_attention_mask"]
+            source_features.append(source_feature)
+
+        base_features = [
+            {
+                key: value
+                for key, value in feature.items()
+                if key not in ("source_input_ids", "source_attention_mask")
+            }
+            for feature in features
+        ]
+
+        batch = self._pad_with_labels(base_features)
+
+        if any(len(source_feature) > 0 for source_feature in source_features):
+            source_batch = self._pad_with_labels(source_features)
+            if "input_ids" in source_batch:
+                batch["source_input_ids"] = source_batch["input_ids"]
+            if "attention_mask" in source_batch:
+                batch["source_attention_mask"] = source_batch["attention_mask"]
+
+        return batch
+
+    def _pad_with_labels(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Pad a single set of features, handling ``labels`` separately.
+
+        ``tokenizer.pad`` only knows how to pad ``input_ids`` and
+        ``attention_mask``, so ``labels`` are padded by hand with
+        ``label_pad_token_id`` on the tokenizer's padding side, matching the
+        behaviour of ``DataCollatorForSeq2Seq``.
+        """
+        labels = (
+            [feature["labels"] for feature in features]
+            if "labels" in features[0]
+            else None
+        )
+
+        no_labels_features = [
+            {key: value for key, value in feature.items() if key != "labels"}
+            for feature in features
+        ]
+
+        batch = self.tokenizer.pad(
+            no_labels_features,
+            padding=self.padding,
+            max_length=self.max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=self.return_tensors,
+        )
+
+        if labels is not None:
+            max_label_length = max(len(label) for label in labels)
+            if self.pad_to_multiple_of is not None:
+                max_label_length = (
+                    (max_label_length + self.pad_to_multiple_of - 1)
+                    // self.pad_to_multiple_of
+                    * self.pad_to_multiple_of
+                )
+
+            padding_side = self.tokenizer.padding_side
+            padded_labels = []
+            for label in labels:
+                remainder = [self.label_pad_token_id] * (
+                    max_label_length - len(label)
+                )
+                label = list(label)
+                if padding_side == "right":
+                    padded_labels.append(label + remainder)
+                else:
+                    padded_labels.append(remainder + label)
+            batch["labels"] = torch.tensor(padded_labels, dtype=torch.int64)
+
+        return batch

--- a/tests/unit_tests/DataCollatorTestCase.py
+++ b/tests/unit_tests/DataCollatorTestCase.py
@@ -1,0 +1,114 @@
+import unittest
+
+import torch
+from tokenizers import Tokenizer, models
+from transformers import PreTrainedTokenizerFast
+
+from pyvene.models.data_collator import DataCollatorForIntervention
+
+
+def build_tiny_tokenizer():
+    """Build a hermetic word level tokenizer so the test needs no downloads."""
+    vocab = {f"tok{i}": i for i in range(16)}
+    vocab["[PAD]"] = 16
+    tokenizer_object = Tokenizer(models.WordLevel(vocab=vocab, unk_token="tok0"))
+    return PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_object, pad_token="[PAD]"
+    )
+
+
+class DataCollatorTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tokenizer = build_tiny_tokenizer()
+        self.pad_id = self.tokenizer.pad_token_id
+        self.collator = DataCollatorForIntervention(tokenizer=self.tokenizer)
+
+    def test_both_sides_pad_to_batch_max(self):
+        # The base set and the source set have different per batch maxima:
+        # base maxes out at length 4, source maxes out at length 5.
+        features = [
+            {
+                "input_ids": [1, 2, 3, 4],
+                "attention_mask": [1, 1, 1, 1],
+                "source_input_ids": [5, 6],
+                "source_attention_mask": [1, 1],
+            },
+            {
+                "input_ids": [7, 8],
+                "attention_mask": [1, 1],
+                "source_input_ids": [9, 10, 11, 12, 13],
+                "source_attention_mask": [1, 1, 1, 1, 1],
+            },
+        ]
+
+        batch = self.collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, (2, 4))
+        self.assertEqual(batch["attention_mask"].shape, (2, 4))
+        self.assertEqual(batch["source_input_ids"].shape, (2, 5))
+        self.assertEqual(batch["source_attention_mask"].shape, (2, 5))
+
+    def test_base_padding_values(self):
+        features = [
+            {"input_ids": [1, 2, 3, 4], "source_input_ids": [5, 6]},
+            {"input_ids": [7, 8], "source_input_ids": [9, 10, 11]},
+        ]
+
+        batch = self.collator(features)
+
+        # The shorter base row is padded on the right with the pad id, and the
+        # attention mask marks the padded position with a zero.
+        self.assertTrue(
+            torch.equal(batch["input_ids"][1], torch.tensor([7, 8, self.pad_id, self.pad_id]))
+        )
+        self.assertTrue(
+            torch.equal(batch["attention_mask"][1], torch.tensor([1, 1, 0, 0]))
+        )
+
+    def test_source_padding_values(self):
+        features = [
+            {"input_ids": [1, 2], "source_input_ids": [5, 6]},
+            {"input_ids": [7, 8], "source_input_ids": [9, 10, 11]},
+        ]
+
+        batch = self.collator(features)
+
+        # The shorter source row is padded on the right with the pad id, and the
+        # generated source attention mask zeroes out the padded position.
+        self.assertTrue(
+            torch.equal(batch["source_input_ids"][0], torch.tensor([5, 6, self.pad_id]))
+        )
+        self.assertTrue(
+            torch.equal(batch["source_attention_mask"][0], torch.tensor([1, 1, 0]))
+        )
+
+    def test_labels_padded_with_ignore_index(self):
+        features = [
+            {"input_ids": [1, 2, 3], "labels": [1, 2, 3], "source_input_ids": [5, 6]},
+            {"input_ids": [7, 8], "labels": [7, 8], "source_input_ids": [9, 10, 11]},
+        ]
+
+        batch = self.collator(features)
+
+        self.assertEqual(batch["labels"].shape, (2, 3))
+        self.assertTrue(
+            torch.equal(
+                batch["labels"][1],
+                torch.tensor([7, 8, self.collator.label_pad_token_id]),
+            )
+        )
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(DataCollatorTestCase("test_both_sides_pad_to_batch_max"))
+    suite.addTest(DataCollatorTestCase("test_base_padding_values"))
+    suite.addTest(DataCollatorTestCase("test_source_padding_values"))
+    suite.addTest(DataCollatorTestCase("test_labels_padded_with_ignore_index"))
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tests/unit_tests/DataCollatorTestCase.py
+++ b/tests/unit_tests/DataCollatorTestCase.py
@@ -99,6 +99,30 @@ class DataCollatorTestCase(unittest.TestCase):
             )
         )
 
+    def test_labels_pad_to_max_length(self):
+        # With padding="max_length" and a max_length, tokenizer.pad pads
+        # input_ids out to max_length, so the labels have to be padded to the
+        # same length rather than to the per batch maximum. Otherwise the loss
+        # compares logits and labels of different lengths.
+        collator = DataCollatorForIntervention(
+            tokenizer=self.tokenizer, padding="max_length", max_length=6
+        )
+        features = [
+            {"input_ids": [1, 2, 3], "labels": [1, 2, 3], "source_input_ids": [5, 6]},
+            {"input_ids": [7, 8], "labels": [7, 8], "source_input_ids": [9, 10, 11]},
+        ]
+
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertEqual(batch["labels"].shape, (2, 6))
+        self.assertTrue(
+            torch.equal(
+                batch["labels"][0],
+                torch.tensor([1, 2, 3] + [collator.label_pad_token_id] * 3),
+            )
+        )
+
 
 def suite():
     suite = unittest.TestSuite()
@@ -106,6 +130,7 @@ def suite():
     suite.addTest(DataCollatorTestCase("test_base_padding_values"))
     suite.addTest(DataCollatorTestCase("test_source_padding_values"))
     suite.addTest(DataCollatorTestCase("test_labels_padded_with_ignore_index"))
+    suite.addTest(DataCollatorTestCase("test_labels_pad_to_max_length"))
     return suite
 
 


### PR DESCRIPTION
This addresses issue #112, which asks for a Hugging Face style collator that works with pyvene models.

Interchange intervention training feeds a pyvene model two sets of inputs per example. The base example contributes input_ids and attention_mask, and the source example contributes source_input_ids and source_attention_mask. These two sets usually have different lengths, so a single collator has to pad both of them to their own per batch maximum before they can be stacked into rectangular tensors.

Hugging Face ships DataCollatorForSeq2Seq, but it only pads input_ids, attention_mask, and labels. The source keys come back ragged, which breaks batched training. The only collator in the repository that touches this area lives inside a quiz notebook and is not exported, so there was no concrete utility a user could import.

This change adds DataCollatorForIntervention in a new module at pyvene/models/data_collator.py and exports it from pyvene so it sits alongside the other utilities. The collator pads the base set the same way DataCollatorForSeq2Seq does and adds matching padding for the source set, padding each side to its own per batch maximum. When labels are present they are padded with label_pad_token_id on the tokenizer's padding side so the loss can ignore the padded positions. It plugs into the inputs_collator hook that train_alignment and eval_alignment already expose in intervenable_base.py, and it touches no intervention internals.

A unit test at tests/unit_tests/DataCollatorTestCase.py builds a small batch where the base and source sides have different lengths and asserts that both sides pad to the batch max. It also checks the pad values, the generated source attention mask, and the label padding. The test uses a tiny in memory tokenizer so it runs without any downloads.

Verification was done in an isolated environment with torch, transformers, and tokenizers installed. The new test passes under pytest and under the repository's own unittest discovery command, and flake8 is clean on the changed files.
