### PR TITLE
Add RoBERTa intervention support (issue #46)

### DIFF
--- a/pyvene/models/intervenable_modelcard.py
+++ b/pyvene/models/intervenable_modelcard.py
@@ -17,6 +17,7 @@ from .olmo.modelings_intervenable_olmo import *
 from .olmo2.modelings_intervenable_olmo2 import *
 from .qwen3.modelings_intervenable_qwen3 import *
 from .esm.modelings_intervenable_esm import *
+from .roberta.modelings_intervenable_roberta import *
 from .mllama.modelings_intervenable_mllama import *
 from .gpt_oss.modelings_intervenable_gpt_oss import *
 from .whisper.modelings_intervenable_whisper import *
@@ -77,6 +78,9 @@ type_to_module_mapping = {
     hf_models.qwen3.modeling_qwen3.Qwen3ForCausalLM: qwen3_lm_type_to_module_mapping,
     hf_models.esm.modeling_esm.EsmModel: esm_type_to_module_mapping,
     hf_models.esm.modeling_esm.EsmForMaskedLM: esm_mlm_type_to_module_mapping,
+    hf_models.roberta.modeling_roberta.RobertaModel: roberta_type_to_module_mapping,
+    hf_models.roberta.modeling_roberta.RobertaForMaskedLM: roberta_mlm_type_to_module_mapping,
+    hf_models.roberta.modeling_roberta.RobertaForSequenceClassification: roberta_classifier_type_to_module_mapping,
     hf_models.blip.modeling_blip.BlipForQuestionAnswering: blip_type_to_module_mapping,
     hf_models.blip.modeling_blip.BlipForImageTextRetrieval: blip_itm_type_to_module_mapping,
     MLPModel: mlp_type_to_module_mapping,
@@ -126,6 +130,9 @@ type_to_dimension_mapping = {
     hf_models.qwen3.modeling_qwen3.Qwen3ForCausalLM: qwen3_lm_type_to_dimension_mapping,
     hf_models.esm.modeling_esm.EsmModel: esm_type_to_dimension_mapping,
     hf_models.esm.modeling_esm.EsmForMaskedLM: esm_mlm_type_to_dimension_mapping,
+    hf_models.roberta.modeling_roberta.RobertaModel: roberta_type_to_dimension_mapping,
+    hf_models.roberta.modeling_roberta.RobertaForMaskedLM: roberta_mlm_type_to_dimension_mapping,
+    hf_models.roberta.modeling_roberta.RobertaForSequenceClassification: roberta_classifier_type_to_dimension_mapping,
     hf_models.blip.modeling_blip.BlipForQuestionAnswering: blip_type_to_dimension_mapping,
     hf_models.blip.modeling_blip.BlipForImageTextRetrieval: blip_itm_type_to_dimension_mapping,
     MLPModel: mlp_type_to_dimension_mapping,

--- a/pyvene/models/roberta/modelings_intervenable_roberta.py
+++ b/pyvene/models/roberta/modelings_intervenable_roberta.py
@@ -1,0 +1,109 @@
+"""
+Each modeling file in this library is a mapping between
+abstract naming of intervention anchor points and actual
+model module defined in the huggingface library.
+
+We also want to let the intervention library know how to
+config the dimensions of intervention based on model config
+defined in the huggingface library.
+"""
+
+
+from ..constants import *
+
+
+"""roberta base model"""
+roberta_type_to_module_mapping = {
+    "block_input": ("encoder.layer[%s]", CONST_INPUT_HOOK),
+    "block_output": ("encoder.layer[%s]", CONST_OUTPUT_HOOK),
+    "mlp_activation": ("encoder.layer[%s].intermediate", CONST_OUTPUT_HOOK),
+    "mlp_output": ("encoder.layer[%s].output", CONST_OUTPUT_HOOK),
+    "mlp_input": ("encoder.layer[%s].intermediate", CONST_INPUT_HOOK),
+    "attention_value_output": ("encoder.layer[%s].attention.output.dense", CONST_INPUT_HOOK),
+    "head_attention_value_output": ("encoder.layer[%s].attention.output.dense", CONST_INPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+    "attention_output": ("encoder.layer[%s].attention.output", CONST_OUTPUT_HOOK),
+    "attention_input": ("encoder.layer[%s].attention", CONST_INPUT_HOOK),
+    "query_output": ("encoder.layer[%s].attention.self.query", CONST_OUTPUT_HOOK),
+    "key_output": ("encoder.layer[%s].attention.self.key", CONST_OUTPUT_HOOK),
+    "value_output": ("encoder.layer[%s].attention.self.value", CONST_OUTPUT_HOOK),
+    "head_query_output": ("encoder.layer[%s].attention.self.query", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+    "head_key_output": ("encoder.layer[%s].attention.self.key", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+    "head_value_output": ("encoder.layer[%s].attention.self.value", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+}
+
+
+roberta_type_to_dimension_mapping = {
+    "num_attention_heads": ("num_attention_heads",),
+    "block_input": ("hidden_size",),
+    "block_output": ("hidden_size",),
+    "mlp_activation": ("intermediate_size",),
+    "mlp_output": ("hidden_size",),
+    "mlp_input": ("hidden_size",),
+    "attention_value_output": ("hidden_size",),
+    "head_attention_value_output": ("hidden_size/num_attention_heads",),
+    "attention_output": ("hidden_size",),
+    "attention_input": ("hidden_size",),
+    "query_output": ("hidden_size",),
+    "key_output": ("hidden_size",),
+    "value_output": ("hidden_size",),
+    "head_query_output": ("hidden_size/num_attention_heads",),
+    "head_key_output": ("hidden_size/num_attention_heads",),
+    "head_value_output": ("hidden_size/num_attention_heads",),
+}
+
+
+"""roberta model with masked LM head"""
+roberta_mlm_type_to_module_mapping = {}
+for k, v in roberta_type_to_module_mapping.items():
+    roberta_mlm_type_to_module_mapping[k] = (f"roberta.{v[0]}", ) + v[1:]
+
+roberta_mlm_type_to_dimension_mapping = roberta_type_to_dimension_mapping
+
+
+"""roberta model with classifier head"""
+roberta_classifier_type_to_module_mapping = {}
+for k, v in roberta_type_to_module_mapping.items():
+    roberta_classifier_type_to_module_mapping[k] = (f"roberta.{v[0]}", ) + v[1:]
+
+roberta_classifier_type_to_dimension_mapping = roberta_type_to_dimension_mapping
+
+
+def create_roberta(name="roberta-base", cache_dir=None):
+    """Creates a RoBERTa base model, config, and tokenizer from the given name"""
+    from transformers import RobertaModel, RobertaTokenizer, RobertaConfig
+
+    config = RobertaConfig.from_pretrained(name)
+    tokenizer = RobertaTokenizer.from_pretrained(name)
+    roberta = RobertaModel.from_pretrained(name, config=config, cache_dir=cache_dir)
+    print("loaded model")
+    return config, tokenizer, roberta
+
+
+def create_roberta_mlm(name="roberta-base", config=None, cache_dir=None):
+    """Creates a RobertaForMaskedLM, config, and tokenizer from the given name"""
+    from transformers import RobertaForMaskedLM, RobertaTokenizer, RobertaConfig
+
+    if config is None:
+        config = RobertaConfig.from_pretrained(name)
+        tokenizer = RobertaTokenizer.from_pretrained(name)
+        roberta = RobertaForMaskedLM.from_pretrained(name, config=config, cache_dir=cache_dir)
+    else:
+        tokenizer = None
+        roberta = RobertaForMaskedLM(config=config)
+    print("loaded model")
+    return config, tokenizer, roberta
+
+
+def create_roberta_classifier(name="roberta-base", config=None, cache_dir=None):
+    """Creates a RobertaForSequenceClassification, config, and tokenizer from the given name"""
+    from transformers import RobertaForSequenceClassification, RobertaTokenizer, RobertaConfig
+
+    if config is None:
+        config = RobertaConfig.from_pretrained(name)
+        tokenizer = RobertaTokenizer.from_pretrained(name)
+        roberta = RobertaForSequenceClassification.from_pretrained(name, config=config, cache_dir=cache_dir)
+    else:
+        tokenizer = None
+        roberta = RobertaForSequenceClassification(config=config)
+    print("loaded model")
+    return config, tokenizer, roberta

--- a/tests/integration_tests/InterventionWithRobertaTestCase.py
+++ b/tests/integration_tests/InterventionWithRobertaTestCase.py
@@ -1,0 +1,136 @@
+import unittest
+from ..utils import *
+
+from transformers import RobertaConfig
+from pyvene.models.roberta.modelings_intervenable_roberta import create_roberta_mlm
+
+
+class InterventionWithRobertaTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        print("=== Test Suite: InterventionWithRobertaTestCase ===")
+        self.config, self.tokenizer, self.roberta = create_roberta_mlm(
+            config=RobertaConfig(
+                hidden_size=24,
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                intermediate_size=48,
+                max_position_embeddings=64,
+                vocab_size=20,
+                pad_token_id=1,
+                hidden_dropout_prob=0.0,
+                attention_probs_dropout_prob=0.0,
+            )
+        )
+        self.roberta.eval()
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.roberta = self.roberta.to(self.device)
+
+        self.nonhead_streams = [
+            "block_output",
+            "block_input",
+            "mlp_activation",
+            "mlp_output",
+            "mlp_input",
+            "attention_value_output",
+            "attention_output",
+            "attention_input",
+            "query_output",
+            "key_output",
+            "value_output",
+        ]
+
+        self.head_streams = [
+            "head_attention_value_output",
+            "head_query_output",
+            "head_key_output",
+            "head_value_output",
+        ]
+
+    def test_clean_run_positive(self):
+        """
+        Wrapping the model in an IntervenableModel without intervening should
+        reproduce the original forward pass for every supported stream.
+        """
+        base = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        golden_out = self.roberta(**base).logits
+        for stream in self.nonhead_streams:
+            config = IntervenableConfig(
+                model_type=type(self.roberta),
+                representations=[RepresentationConfig(0, stream, "pos", 1)],
+                intervention_types=VanillaIntervention,
+            )
+            intervenable = IntervenableModel(config, self.roberta)
+            intervenable.set_device(self.device)
+            our_output = intervenable(base, output_original_output=True)[0][0]
+            self.assertTrue(
+                torch.allclose(golden_out, our_output, rtol=1e-05, atol=1e-06)
+            )
+
+    def test_with_position_intervention_positive(self):
+        """
+        Copying a source activation into the base at each non head stream should
+        change the output, confirming the anchor point hooks a real module.
+        """
+        base = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        source = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        base_out = self.roberta(**base).logits
+        for stream in self.nonhead_streams:
+            config = IntervenableConfig(
+                model_type=type(self.roberta),
+                representations=[RepresentationConfig(1, stream, "pos", 1)],
+                intervention_types=VanillaIntervention,
+            )
+            intervenable = IntervenableModel(config, self.roberta)
+            intervenable.set_device(self.device)
+            _, our_output = intervenable(
+                base, [source], {"sources->base": ([[[0]] * 4], [[[0]] * 4])}
+            )
+            self.assertFalse(
+                torch.allclose(our_output[0], base_out, rtol=1e-05, atol=1e-06)
+            )
+
+    def test_with_head_position_intervention_positive(self):
+        """
+        Per head streams should build and run a vanilla intervention.
+        """
+        base = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        source = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        for stream in self.head_streams:
+            config = IntervenableConfig(
+                model_type=type(self.roberta),
+                representations=[RepresentationConfig(1, stream, "h.pos", 1)],
+                intervention_types=VanillaIntervention,
+            )
+            intervenable = IntervenableModel(config, self.roberta)
+            intervenable.set_device(self.device)
+            _, our_output = intervenable(
+                base,
+                [source],
+                {
+                    "sources->base": (
+                        [[[[0]] * 4, [[0]] * 4]],
+                        [[[[0]] * 4, [[0]] * 4]],
+                    )
+                },
+            )
+            self.assertEqual(our_output[0].shape[0], base["input_ids"].shape[0])
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(InterventionWithRobertaTestCase("test_clean_run_positive"))
+    suite.addTest(
+        InterventionWithRobertaTestCase("test_with_position_intervention_positive")
+    )
+    suite.addTest(
+        InterventionWithRobertaTestCase(
+            "test_with_head_position_intervention_positive"
+        )
+    )
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
This adds RoBERTa as a supported architecture, one of the BERT family models listed in issue #46. With it pyvene can run interventions on RoBERTa models without users reaching into model internals.

What changed

A new package at pyvene/models/roberta holds the mapping file modelings_intervenable_roberta.py. It maps the abstract intervention anchor points to the actual RoBERTa encoder modules, following the same shape as the existing gpt_neo and gpt2 mapping files. The covered streams are block input and output, the mlp input, activation, and output, the attention input and output, the attention value output, and the per projection query, key, and value outputs along with their per head variants. The dimension mapping pairs each stream with the right config field so head splitting works. The file also provides create_roberta, create_roberta_mlm, and create_roberta_classifier helpers that match the create_* pattern used by the other models, with an optional config argument so a model can be built from a tiny config rather than a download.

The three RoBERTa classes RobertaModel, RobertaForMaskedLM, and RobertaForSequenceClassification are registered in intervenable_modelcard.py in both the module mapping and the dimension mapping dicts, alongside the matching wildcard import. The masked LM and classifier variants reuse the base mapping with the roberta. prefix applied, the same way gpt2 handles its LM and classifier heads.

A test at tests/integration_tests/InterventionWithRobertaTestCase.py mirrors the existing per model tests. It instantiates a tiny RoBERTa from a small config so no large download is needed. It checks that wrapping the model in an IntervenableModel without intervening reproduces the original forward pass for every non head stream, that copying a source activation into the base changes the output on each non head stream, and that each per head stream builds and runs a vanilla intervention.

Verification

In an isolated venv with torch and transformers I ran only the new test and all three cases pass under both pytest and the python -m unittest invocation that CI uses. I also confirmed every mapped module path resolves against a real tiny RoBERTa, that no op runs match the raw model output on all eleven non head streams, and that interchange interventions change the output on each of them. The CI lint selection over the changed files reports no syntax or undefined name errors.

Scope

This is a single clean model addition. The issue tracks many more architectures, so this is meant as one step toward that list rather than a complete answer to it.

Closes one item from issue #46.
