### PR TITLE
Add ELECTRA model support (#46)

### DIFF
--- a/pyvene/models/electra/modelings_intervenable_electra.py
+++ b/pyvene/models/electra/modelings_intervenable_electra.py
@@ -1,0 +1,109 @@
+"""
+Each modeling file in this library is a mapping between
+abstract naming of intervention anchor points and actual
+model module defined in the huggingface library.
+
+We also want to let the intervention library know how to
+config the dimensions of intervention based on model config
+defined in the huggingface library.
+"""
+
+
+from ..constants import *
+
+
+"""electra base model"""
+electra_type_to_module_mapping = {
+    "block_input": ("encoder.layer[%s]", CONST_INPUT_HOOK),
+    "block_output": ("encoder.layer[%s]", CONST_OUTPUT_HOOK),
+    "mlp_activation": ("encoder.layer[%s].intermediate", CONST_OUTPUT_HOOK),
+    "mlp_output": ("encoder.layer[%s].output", CONST_OUTPUT_HOOK),
+    "mlp_input": ("encoder.layer[%s].intermediate", CONST_INPUT_HOOK),
+    "attention_value_output": ("encoder.layer[%s].attention.output.dense", CONST_INPUT_HOOK),
+    "head_attention_value_output": ("encoder.layer[%s].attention.output.dense", CONST_INPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+    "attention_output": ("encoder.layer[%s].attention.output", CONST_OUTPUT_HOOK),
+    "attention_input": ("encoder.layer[%s].attention", CONST_INPUT_HOOK),
+    "query_output": ("encoder.layer[%s].attention.self.query", CONST_OUTPUT_HOOK),
+    "key_output": ("encoder.layer[%s].attention.self.key", CONST_OUTPUT_HOOK),
+    "value_output": ("encoder.layer[%s].attention.self.value", CONST_OUTPUT_HOOK),
+    "head_query_output": ("encoder.layer[%s].attention.self.query", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+    "head_key_output": ("encoder.layer[%s].attention.self.key", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+    "head_value_output": ("encoder.layer[%s].attention.self.value", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_attention_heads")),
+}
+
+
+electra_type_to_dimension_mapping = {
+    "num_attention_heads": ("num_attention_heads",),
+    "block_input": ("hidden_size",),
+    "block_output": ("hidden_size",),
+    "mlp_activation": ("intermediate_size",),
+    "mlp_output": ("hidden_size",),
+    "mlp_input": ("hidden_size",),
+    "attention_value_output": ("hidden_size",),
+    "head_attention_value_output": ("hidden_size/num_attention_heads",),
+    "attention_output": ("hidden_size",),
+    "attention_input": ("hidden_size",),
+    "query_output": ("hidden_size",),
+    "key_output": ("hidden_size",),
+    "value_output": ("hidden_size",),
+    "head_query_output": ("hidden_size/num_attention_heads",),
+    "head_key_output": ("hidden_size/num_attention_heads",),
+    "head_value_output": ("hidden_size/num_attention_heads",),
+}
+
+
+"""electra model with masked LM head"""
+electra_mlm_type_to_module_mapping = {}
+for k, v in electra_type_to_module_mapping.items():
+    electra_mlm_type_to_module_mapping[k] = (f"electra.{v[0]}", ) + v[1:]
+
+electra_mlm_type_to_dimension_mapping = electra_type_to_dimension_mapping
+
+
+"""electra model with classifier head"""
+electra_classifier_type_to_module_mapping = {}
+for k, v in electra_type_to_module_mapping.items():
+    electra_classifier_type_to_module_mapping[k] = (f"electra.{v[0]}", ) + v[1:]
+
+electra_classifier_type_to_dimension_mapping = electra_type_to_dimension_mapping
+
+
+def create_electra(name="google/electra-base-discriminator", cache_dir=None):
+    """Creates an ELECTRA base model, config, and tokenizer from the given name"""
+    from transformers import ElectraModel, ElectraTokenizer, ElectraConfig
+
+    config = ElectraConfig.from_pretrained(name)
+    tokenizer = ElectraTokenizer.from_pretrained(name)
+    electra = ElectraModel.from_pretrained(name, config=config, cache_dir=cache_dir)
+    print("loaded model")
+    return config, tokenizer, electra
+
+
+def create_electra_mlm(name="google/electra-base-generator", config=None, cache_dir=None):
+    """Creates an ElectraForMaskedLM, config, and tokenizer from the given name"""
+    from transformers import ElectraForMaskedLM, ElectraTokenizer, ElectraConfig
+
+    if config is None:
+        config = ElectraConfig.from_pretrained(name)
+        tokenizer = ElectraTokenizer.from_pretrained(name)
+        electra = ElectraForMaskedLM.from_pretrained(name, config=config, cache_dir=cache_dir)
+    else:
+        tokenizer = None
+        electra = ElectraForMaskedLM(config=config)
+    print("loaded model")
+    return config, tokenizer, electra
+
+
+def create_electra_classifier(name="google/electra-base-discriminator", config=None, cache_dir=None):
+    """Creates an ElectraForSequenceClassification, config, and tokenizer from the given name"""
+    from transformers import ElectraForSequenceClassification, ElectraTokenizer, ElectraConfig
+
+    if config is None:
+        config = ElectraConfig.from_pretrained(name)
+        tokenizer = ElectraTokenizer.from_pretrained(name)
+        electra = ElectraForSequenceClassification.from_pretrained(name, config=config, cache_dir=cache_dir)
+    else:
+        tokenizer = None
+        electra = ElectraForSequenceClassification(config=config)
+    print("loaded model")
+    return config, tokenizer, electra

--- a/pyvene/models/intervenable_modelcard.py
+++ b/pyvene/models/intervenable_modelcard.py
@@ -17,6 +17,7 @@ from .olmo.modelings_intervenable_olmo import *
 from .olmo2.modelings_intervenable_olmo2 import *
 from .qwen3.modelings_intervenable_qwen3 import *
 from .esm.modelings_intervenable_esm import *
+from .electra.modelings_intervenable_electra import *
 from .mllama.modelings_intervenable_mllama import *
 from .gpt_oss.modelings_intervenable_gpt_oss import *
 from .whisper.modelings_intervenable_whisper import *
@@ -77,6 +78,9 @@ type_to_module_mapping = {
     hf_models.qwen3.modeling_qwen3.Qwen3ForCausalLM: qwen3_lm_type_to_module_mapping,
     hf_models.esm.modeling_esm.EsmModel: esm_type_to_module_mapping,
     hf_models.esm.modeling_esm.EsmForMaskedLM: esm_mlm_type_to_module_mapping,
+    hf_models.electra.modeling_electra.ElectraModel: electra_type_to_module_mapping,
+    hf_models.electra.modeling_electra.ElectraForMaskedLM: electra_mlm_type_to_module_mapping,
+    hf_models.electra.modeling_electra.ElectraForSequenceClassification: electra_classifier_type_to_module_mapping,
     hf_models.blip.modeling_blip.BlipForQuestionAnswering: blip_type_to_module_mapping,
     hf_models.blip.modeling_blip.BlipForImageTextRetrieval: blip_itm_type_to_module_mapping,
     MLPModel: mlp_type_to_module_mapping,
@@ -126,6 +130,9 @@ type_to_dimension_mapping = {
     hf_models.qwen3.modeling_qwen3.Qwen3ForCausalLM: qwen3_lm_type_to_dimension_mapping,
     hf_models.esm.modeling_esm.EsmModel: esm_type_to_dimension_mapping,
     hf_models.esm.modeling_esm.EsmForMaskedLM: esm_mlm_type_to_dimension_mapping,
+    hf_models.electra.modeling_electra.ElectraModel: electra_type_to_dimension_mapping,
+    hf_models.electra.modeling_electra.ElectraForMaskedLM: electra_mlm_type_to_dimension_mapping,
+    hf_models.electra.modeling_electra.ElectraForSequenceClassification: electra_classifier_type_to_dimension_mapping,
     hf_models.blip.modeling_blip.BlipForQuestionAnswering: blip_type_to_dimension_mapping,
     hf_models.blip.modeling_blip.BlipForImageTextRetrieval: blip_itm_type_to_dimension_mapping,
     MLPModel: mlp_type_to_dimension_mapping,

--- a/tests/integration_tests/InterventionWithElectraTestCase.py
+++ b/tests/integration_tests/InterventionWithElectraTestCase.py
@@ -1,0 +1,137 @@
+import unittest
+from ..utils import *
+
+from transformers import ElectraConfig
+from pyvene.models.electra.modelings_intervenable_electra import create_electra_mlm
+
+
+class InterventionWithElectraTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        print("=== Test Suite: InterventionWithElectraTestCase ===")
+        self.config, self.tokenizer, self.electra = create_electra_mlm(
+            config=ElectraConfig(
+                hidden_size=24,
+                embedding_size=24,
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                intermediate_size=48,
+                max_position_embeddings=64,
+                vocab_size=20,
+                pad_token_id=1,
+                hidden_dropout_prob=0.0,
+                attention_probs_dropout_prob=0.0,
+            )
+        )
+        self.electra.eval()
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.electra = self.electra.to(self.device)
+
+        self.nonhead_streams = [
+            "block_output",
+            "block_input",
+            "mlp_activation",
+            "mlp_output",
+            "mlp_input",
+            "attention_value_output",
+            "attention_output",
+            "attention_input",
+            "query_output",
+            "key_output",
+            "value_output",
+        ]
+
+        self.head_streams = [
+            "head_attention_value_output",
+            "head_query_output",
+            "head_key_output",
+            "head_value_output",
+        ]
+
+    def test_clean_run_positive(self):
+        """
+        Wrapping the model in an IntervenableModel without intervening should
+        reproduce the original forward pass for every supported stream.
+        """
+        base = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        golden_out = self.electra(**base).logits
+        for stream in self.nonhead_streams:
+            config = IntervenableConfig(
+                model_type=type(self.electra),
+                representations=[RepresentationConfig(0, stream, "pos", 1)],
+                intervention_types=VanillaIntervention,
+            )
+            intervenable = IntervenableModel(config, self.electra)
+            intervenable.set_device(self.device)
+            our_output = intervenable(base, output_original_output=True)[0][0]
+            self.assertTrue(
+                torch.allclose(golden_out, our_output, rtol=1e-05, atol=1e-06)
+            )
+
+    def test_with_position_intervention_positive(self):
+        """
+        Copying a source activation into the base at each non head stream should
+        change the output, confirming the anchor point hooks a real module.
+        """
+        base = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        source = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        base_out = self.electra(**base).logits
+        for stream in self.nonhead_streams:
+            config = IntervenableConfig(
+                model_type=type(self.electra),
+                representations=[RepresentationConfig(1, stream, "pos", 1)],
+                intervention_types=VanillaIntervention,
+            )
+            intervenable = IntervenableModel(config, self.electra)
+            intervenable.set_device(self.device)
+            _, our_output = intervenable(
+                base, [source], {"sources->base": ([[[0]] * 4], [[[0]] * 4])}
+            )
+            self.assertFalse(
+                torch.allclose(our_output[0], base_out, rtol=1e-05, atol=1e-06)
+            )
+
+    def test_with_head_position_intervention_positive(self):
+        """
+        Per head streams should build and run a vanilla intervention.
+        """
+        base = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        source = {"input_ids": torch.randint(2, 20, (4, 6)).to(self.device)}
+        for stream in self.head_streams:
+            config = IntervenableConfig(
+                model_type=type(self.electra),
+                representations=[RepresentationConfig(1, stream, "h.pos", 1)],
+                intervention_types=VanillaIntervention,
+            )
+            intervenable = IntervenableModel(config, self.electra)
+            intervenable.set_device(self.device)
+            _, our_output = intervenable(
+                base,
+                [source],
+                {
+                    "sources->base": (
+                        [[[[0]] * 4, [[0]] * 4]],
+                        [[[[0]] * 4, [[0]] * 4]],
+                    )
+                },
+            )
+            self.assertEqual(our_output[0].shape[0], base["input_ids"].shape[0])
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(InterventionWithElectraTestCase("test_clean_run_positive"))
+    suite.addTest(
+        InterventionWithElectraTestCase("test_with_position_intervention_positive")
+    )
+    suite.addTest(
+        InterventionWithElectraTestCase(
+            "test_with_head_position_intervention_positive"
+        )
+    )
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
## Summary

Adds intervention support for **ELECTRA** (`google/electra-*`), addressing the BERT-family item in #46 (`[P1] Support more huggingface models` — "RoBERTa, DeBERTa, ELECTRA"). RoBERTa is already in progress (#237), so this covers ELECTRA.

ELECTRA uses the standard BERT encoder layout, so the intervention mapping mirrors the existing ESM/RoBERTa encoders. Supported model classes:

- `ElectraModel`
- `ElectraForMaskedLM`
- `ElectraForSequenceClassification`

## What's included

- `pyvene/models/electra/modelings_intervenable_electra.py` — module/dimension mappings for all standard streams (block, mlp in/activation/output, attention in/out/value, and per-head query/key/value with `split_head_and_permute`), plus `create_electra` / `create_electra_mlm` / `create_electra_classifier` helpers.
- Registration of the three classes in `pyvene/models/intervenable_modelcard.py` (module + dimension mappings).
- `tests/integration_tests/InterventionWithElectraTestCase.py`.

## Testing

Run on a tiny in-memory config (no downloads), mirroring the other model test cases:

```
python -m unittest tests.integration_tests.InterventionWithElectraTestCase -v
# Ran 3 tests ... OK
```

- `test_clean_run_positive` — a no-op `VanillaIntervention` reproduces the raw forward pass across all 11 non-head streams.
- `test_with_position_intervention_positive` — copying a source activation changes the output at each non-head stream (confirms each anchor hooks a real module).
- `test_with_head_position_intervention_positive` — per-head query/key/value/attention-value streams build and run.

The existing suite (e.g. `InterventionWithMLPTestCase`) still passes, confirming the modelcard change is non-breaking.
