### PR TITLE
Add T5 model support (#46)

### DIFF
--- a/pyvene/models/intervenable_modelcard.py
+++ b/pyvene/models/intervenable_modelcard.py
@@ -21,6 +21,7 @@ from .mllama.modelings_intervenable_mllama import *
 from .gpt_oss.modelings_intervenable_gpt_oss import *
 from .whisper.modelings_intervenable_whisper import *
 from .wav2vec2bert.modelings_intervenable_wav2vec2bert import *
+from .t5.modelings_intervenable_t5 import *
 
 #########################################################################
 """
@@ -94,6 +95,9 @@ type_to_module_mapping = {
     hf_models.whisper.modeling_whisper.WhisperModel: whisper_type_to_module_mapping,
     hf_models.whisper.modeling_whisper.WhisperForConditionalGeneration: whisper_lm_type_to_module_mapping,
     hf_models.wav2vec2_bert.modeling_wav2vec2_bert.Wav2Vec2BertModel: wav2vec2bert_type_to_module_mapping,
+    hf_models.t5.modeling_t5.T5Model: t5_type_to_module_mapping,
+    hf_models.t5.modeling_t5.T5EncoderModel: t5_encoder_type_to_module_mapping,
+    hf_models.t5.modeling_t5.T5ForConditionalGeneration: t5_lm_type_to_module_mapping,
 }
 if enable_blip:
     type_to_module_mapping[BlipWrapper] = blip_wrapper_type_to_module_mapping
@@ -143,6 +147,9 @@ type_to_dimension_mapping = {
     hf_models.whisper.modeling_whisper.WhisperModel: whisper_type_to_dimension_mapping,
     hf_models.whisper.modeling_whisper.WhisperForConditionalGeneration: whisper_lm_type_to_dimension_mapping,
     hf_models.wav2vec2_bert.modeling_wav2vec2_bert.Wav2Vec2BertModel: wav2vec2bert_type_to_dimension_mapping,
+    hf_models.t5.modeling_t5.T5Model: t5_type_to_dimension_mapping,
+    hf_models.t5.modeling_t5.T5EncoderModel: t5_encoder_type_to_dimension_mapping,
+    hf_models.t5.modeling_t5.T5ForConditionalGeneration: t5_lm_type_to_dimension_mapping,
 }
 
 if enable_blip:

--- a/pyvene/models/t5/modelings_intervenable_t5.py
+++ b/pyvene/models/t5/modelings_intervenable_t5.py
@@ -1,0 +1,128 @@
+"""
+Each modeling file in this library is a mapping between
+abstract naming of intervention anchor points and actual
+model module defined in the huggingface library.
+
+We also want to let the intervention library know how to
+config the dimensions of intervention based on model config
+defined in the huggingface library.
+"""
+
+
+import torch
+from ..constants import *
+
+
+"""t5 base model (encoder-only anchor paths)
+
+T5 is an encoder-decoder model. For parity with the existing whisper
+mapping in this library, the standard anchor names address the encoder
+stack. The encoder block layout is:
+    encoder.block[i].layer[0]  -> self-attention sublayer
+    encoder.block[i].layer[1]  -> feed-forward sublayer
+
+Note on dimensions: T5 attention uses an inner dimension of
+``num_heads * d_kv`` (which can differ from ``d_model``), so the q/k/v/o
+projections are sized by ``inner_dim``, not by ``d_model``. We therefore
+expose ``inner_dim = num_heads*d_kv`` via the dimension mapping.
+"""
+t5_type_to_module_mapping = {
+    "block_input": ("encoder.block[%s]", CONST_INPUT_HOOK),
+    "block_output": ("encoder.block[%s]", CONST_OUTPUT_HOOK),
+    "mlp_activation": ("encoder.block[%s].layer[1].DenseReluDense.act", CONST_OUTPUT_HOOK),
+    "mlp_output": ("encoder.block[%s].layer[1].DenseReluDense.wo", CONST_OUTPUT_HOOK),
+    "mlp_input": ("encoder.block[%s].layer[1].DenseReluDense.wi", CONST_INPUT_HOOK),
+    "attention_value_output": ("encoder.block[%s].layer[0].SelfAttention.o", CONST_INPUT_HOOK),
+    "head_attention_value_output": ("encoder.block[%s].layer[0].SelfAttention.o", CONST_INPUT_HOOK, (split_head_and_permute, "num_heads")),
+    "attention_output": ("encoder.block[%s].layer[0].SelfAttention", CONST_OUTPUT_HOOK),
+    "attention_input": ("encoder.block[%s].layer[0].SelfAttention", CONST_INPUT_HOOK),
+    "query_output": ("encoder.block[%s].layer[0].SelfAttention.q", CONST_OUTPUT_HOOK),
+    "key_output": ("encoder.block[%s].layer[0].SelfAttention.k", CONST_OUTPUT_HOOK),
+    "value_output": ("encoder.block[%s].layer[0].SelfAttention.v", CONST_OUTPUT_HOOK),
+    "head_query_output": ("encoder.block[%s].layer[0].SelfAttention.q", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_heads")),
+    "head_key_output": ("encoder.block[%s].layer[0].SelfAttention.k", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_heads")),
+    "head_value_output": ("encoder.block[%s].layer[0].SelfAttention.v", CONST_OUTPUT_HOOK, (split_head_and_permute, "num_heads")),
+}
+
+
+t5_type_to_dimension_mapping = {
+    "num_heads": ("num_heads",),
+    "block_input": ("d_model",),
+    "block_output": ("d_model",),
+    "mlp_activation": ("d_ff",),
+    "mlp_output": ("d_model",),
+    "mlp_input": ("d_model",),
+    "attention_value_output": ("num_heads*d_kv",),
+    "head_attention_value_output": ("d_kv",),
+    "attention_output": ("d_model",),
+    "attention_input": ("d_model",),
+    "query_output": ("num_heads*d_kv",),
+    "key_output": ("num_heads*d_kv",),
+    "value_output": ("num_heads*d_kv",),
+    "head_query_output": ("d_kv",),
+    "head_key_output": ("d_kv",),
+    "head_value_output": ("d_kv",),
+}
+
+
+"""t5 encoder-only model (T5EncoderModel)
+
+T5EncoderModel exposes the encoder stack at the top level (i.e. its
+module names are already ``encoder.block[i]....``), so the encoder-only
+anchor paths above can be reused as-is.
+"""
+t5_encoder_type_to_module_mapping = dict(t5_type_to_module_mapping)
+t5_encoder_type_to_dimension_mapping = t5_type_to_dimension_mapping
+
+
+"""t5 model with conditional generation head (T5ForConditionalGeneration)
+
+T5ForConditionalGeneration wraps the encoder/decoder under no additional
+prefix — the encoder is still reachable at ``encoder.block[i]...`` — so
+the encoder-only anchor mapping can be reused unchanged.
+"""
+t5_lm_type_to_module_mapping = dict(t5_type_to_module_mapping)
+t5_lm_type_to_dimension_mapping = t5_type_to_dimension_mapping
+
+
+def create_t5(name="google-t5/t5-small", cache_dir=None):
+    """Creates a T5Model, config, and tokenizer from the given name."""
+    from transformers import T5Config, T5Model, T5Tokenizer
+
+    config = T5Config.from_pretrained(name)
+    tokenizer = T5Tokenizer.from_pretrained(name)
+    t5 = T5Model.from_pretrained(name, config=config, cache_dir=cache_dir)
+    print("loaded model")
+    return config, tokenizer, t5
+
+
+def create_t5_lm(name="google-t5/t5-small", config=None, cache_dir=None):
+    """Creates a T5ForConditionalGeneration, config, and tokenizer."""
+    from transformers import T5Config, T5ForConditionalGeneration, T5Tokenizer
+
+    if config is None:
+        config = T5Config.from_pretrained(name)
+        tokenizer = T5Tokenizer.from_pretrained(name)
+        t5 = T5ForConditionalGeneration.from_pretrained(
+            name, config=config, cache_dir=cache_dir
+        )
+    else:
+        tokenizer = None
+        t5 = T5ForConditionalGeneration(config=config)
+    print("loaded model")
+    return config, tokenizer, t5
+
+
+def create_t5_encoder(name="google-t5/t5-small", config=None, cache_dir=None):
+    """Creates a T5EncoderModel, config, and tokenizer."""
+    from transformers import T5Config, T5EncoderModel, T5Tokenizer
+
+    if config is None:
+        config = T5Config.from_pretrained(name)
+        tokenizer = T5Tokenizer.from_pretrained(name)
+        t5 = T5EncoderModel.from_pretrained(name, config=config, cache_dir=cache_dir)
+    else:
+        tokenizer = None
+        t5 = T5EncoderModel(config=config)
+    print("loaded model")
+    return config, tokenizer, t5

--- a/pyvene/models/t5/modelings_intervenable_t5.py
+++ b/pyvene/models/t5/modelings_intervenable_t5.py
@@ -25,13 +25,24 @@ Note on dimensions: T5 attention uses an inner dimension of
 ``num_heads * d_kv`` (which can differ from ``d_model``), so the q/k/v/o
 projections are sized by ``inner_dim``, not by ``d_model``. We therefore
 expose ``inner_dim = num_heads*d_kv`` via the dimension mapping.
+
+Note on the feed-forward sublayer: HF instantiates one of two modules at
+``layer[1].DenseReluDense`` depending on ``config.feed_forward_proj``.
+Vanilla T5 (``relu``) uses ``T5DenseActDense`` which exposes a single
+``wi`` linear; T5 v1.1 / FLAN-T5 / mT5 (``gated-gelu``) use
+``T5DenseGatedActDense`` which exposes ``wi_0`` and ``wi_1`` and has no
+``wi`` attribute. We therefore anchor ``mlp_input`` on the
+``DenseReluDense`` module itself — its INPUT_HOOK sees the same tensor
+that flows into ``wi`` (or ``wi_0``/``wi_1``) and works for both
+variants. ``mlp_activation`` and ``mlp_output`` are unaffected because
+both classes expose ``.act`` and ``.wo``.
 """
 t5_type_to_module_mapping = {
     "block_input": ("encoder.block[%s]", CONST_INPUT_HOOK),
     "block_output": ("encoder.block[%s]", CONST_OUTPUT_HOOK),
     "mlp_activation": ("encoder.block[%s].layer[1].DenseReluDense.act", CONST_OUTPUT_HOOK),
     "mlp_output": ("encoder.block[%s].layer[1].DenseReluDense.wo", CONST_OUTPUT_HOOK),
-    "mlp_input": ("encoder.block[%s].layer[1].DenseReluDense.wi", CONST_INPUT_HOOK),
+    "mlp_input": ("encoder.block[%s].layer[1].DenseReluDense", CONST_INPUT_HOOK),
     "attention_value_output": ("encoder.block[%s].layer[0].SelfAttention.o", CONST_INPUT_HOOK),
     "head_attention_value_output": ("encoder.block[%s].layer[0].SelfAttention.o", CONST_INPUT_HOOK, (split_head_and_permute, "num_heads")),
     "attention_output": ("encoder.block[%s].layer[0].SelfAttention", CONST_OUTPUT_HOOK),

--- a/tests/integration_tests/InterventionWithT5TestCase.py
+++ b/tests/integration_tests/InterventionWithT5TestCase.py
@@ -145,12 +145,78 @@ class InterventionWithT5TestCase(unittest.TestCase):
                 )
                 IntervenableModel(config, self.t5_lm)
 
+    def test_mlp_input_resolves_on_gated_gelu_variant(self):
+        """T5 v1.1 / FLAN-T5 / mT5 use ``feed_forward_proj='gated-gelu'``,
+        which swaps ``T5DenseActDense`` (with ``wi``) for
+        ``T5DenseGatedActDense`` (with ``wi_0`` and ``wi_1`` and no
+        ``wi``). The ``mlp_input`` anchor must resolve and intervene on
+        that variant — pointing the path at ``DenseReluDense.wi`` would
+        AttributeError here."""
+        _, _, gated_encoder = create_t5_encoder(
+            config=T5Config(
+                d_model=24,
+                d_ff=48,
+                d_kv=6,
+                num_layers=4,
+                num_decoder_layers=4,
+                num_heads=4,
+                vocab_size=20,
+                pad_token_id=0,
+                eos_token_id=1,
+                decoder_start_token_id=0,
+                dropout_rate=0.0,
+                feed_forward_proj="gated-gelu",
+            )
+        )
+        gated_encoder.eval().to(self.device)
+
+        # Sanity-check the assumption this test exists to lock in: the
+        # FF sublayer really is the gated variant with no `wi`.
+        ff = gated_encoder.encoder.block[0].layer[1].DenseReluDense
+        self.assertEqual(type(ff).__name__, "T5DenseGatedActDense")
+        self.assertFalse(hasattr(ff, "wi"))
+        self.assertTrue(hasattr(ff, "wi_0") and hasattr(ff, "wi_1"))
+
+        b_s, seq_len = 2, 6
+        base_ids = torch.randint(2, 20, (b_s, seq_len)).to(self.device)
+        src_ids = torch.randint(2, 20, (b_s, seq_len)).to(self.device)
+        base_mask = torch.ones_like(base_ids).to(self.device)
+        src_mask = torch.ones_like(src_ids).to(self.device)
+
+        config = IntervenableConfig(
+            model_type=type(gated_encoder),
+            representations=[
+                RepresentationConfig(0, "mlp_input", "pos", 1),
+            ],
+            intervention_types=VanillaIntervention,
+        )
+        intervenable = IntervenableModel(config, gated_encoder)
+
+        with torch.no_grad():
+            base_out = gated_encoder(
+                input_ids=base_ids, attention_mask=base_mask
+            ).last_hidden_state
+            _, intervened = intervenable(
+                base={"input_ids": base_ids, "attention_mask": base_mask},
+                sources=[
+                    {"input_ids": src_ids, "attention_mask": src_mask}
+                ],
+                unit_locations={"sources->base": ([[[2]] * b_s], [[[2]] * b_s])},
+            )
+        self.assertFalse(
+            torch.allclose(base_out, intervened.last_hidden_state),
+            "mlp_input intervention on gated-gelu T5 did not change output.",
+        )
+
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(InterventionWithT5TestCase("test_nonhead_streams_encoder"))
     suite.addTest(InterventionWithT5TestCase("test_head_streams_encoder"))
     suite.addTest(InterventionWithT5TestCase("test_lm_encoder_anchors_resolve"))
+    suite.addTest(
+        InterventionWithT5TestCase("test_mlp_input_resolves_on_gated_gelu_variant")
+    )
     return suite
 
 

--- a/tests/integration_tests/InterventionWithT5TestCase.py
+++ b/tests/integration_tests/InterventionWithT5TestCase.py
@@ -1,0 +1,159 @@
+import unittest
+from ..utils import *
+
+from transformers import T5Config
+from pyvene.models.t5.modelings_intervenable_t5 import (
+    create_t5_encoder,
+    create_t5_lm,
+)
+
+
+class InterventionWithT5TestCase(unittest.TestCase):
+    """Smoke tests for the T5 anchor mapping.
+
+    These verify that every advertised anchor in
+    ``t5_type_to_module_mapping`` (a) resolves to a real submodule on a
+    small randomly-initialised T5 and (b) actually changes the model's
+    output when intervened on. Tests run on CPU using a tiny config so
+    no checkpoint download is required.
+    """
+
+    @classmethod
+    def setUpClass(self):
+        print("=== Test Suite: InterventionWithT5TestCase ===")
+        self.config, _, self.t5_encoder = create_t5_encoder(
+            config=T5Config(
+                d_model=24,
+                d_ff=48,
+                d_kv=6,
+                num_layers=4,
+                num_decoder_layers=4,
+                num_heads=4,
+                vocab_size=20,
+                pad_token_id=0,
+                eos_token_id=1,
+                decoder_start_token_id=0,
+                dropout_rate=0.0,
+            )
+        )
+        self.t5_encoder.eval()
+        _, _, self.t5_lm = create_t5_lm(
+            config=T5Config(
+                d_model=24,
+                d_ff=48,
+                d_kv=6,
+                num_layers=4,
+                num_decoder_layers=4,
+                num_heads=4,
+                vocab_size=20,
+                pad_token_id=0,
+                eos_token_id=1,
+                decoder_start_token_id=0,
+                dropout_rate=0.0,
+            )
+        )
+        self.t5_lm.eval()
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.t5_encoder = self.t5_encoder.to(self.device)
+        self.t5_lm = self.t5_lm.to(self.device)
+
+        self.nonhead_streams = [
+            "block_output",
+            "block_input",
+            "mlp_activation",
+            "mlp_output",
+            "mlp_input",
+            "attention_value_output",
+            "attention_output",
+            "attention_input",
+            "query_output",
+            "key_output",
+            "value_output",
+        ]
+
+        self.head_streams = [
+            "head_attention_value_output",
+            "head_query_output",
+            "head_key_output",
+            "head_value_output",
+        ]
+
+    def _zero_intervention_changes_output_encoder(self, stream):
+        """Patching with activations from a different source input at a
+        single position should perturb the encoder's last_hidden_state."""
+        b_s, seq_len = 2, 6
+        base_ids = torch.randint(2, 20, (b_s, seq_len)).to(self.device)
+        src_ids = torch.randint(2, 20, (b_s, seq_len)).to(self.device)
+        base_mask = torch.ones_like(base_ids).to(self.device)
+        src_mask = torch.ones_like(src_ids).to(self.device)
+
+        config = IntervenableConfig(
+            model_type=type(self.t5_encoder),
+            representations=[
+                RepresentationConfig(0, stream, "pos", 1),
+            ],
+            intervention_types=VanillaIntervention,
+        )
+        intervenable = IntervenableModel(config, self.t5_encoder)
+
+        with torch.no_grad():
+            base_out = self.t5_encoder(
+                input_ids=base_ids, attention_mask=base_mask
+            ).last_hidden_state
+            _, intervened = intervenable(
+                base={"input_ids": base_ids, "attention_mask": base_mask},
+                sources=[
+                    {"input_ids": src_ids, "attention_mask": src_mask}
+                ],
+                unit_locations={"sources->base": ([[[2]] * b_s], [[[2]] * b_s])},
+            )
+        self.assertFalse(
+            torch.allclose(base_out, intervened.last_hidden_state),
+            f"Intervention on stream '{stream}' did not change encoder output.",
+        )
+
+    def test_nonhead_streams_encoder(self):
+        for stream in self.nonhead_streams:
+            with self.subTest(stream=stream):
+                self._zero_intervention_changes_output_encoder(stream)
+
+    def test_head_streams_encoder(self):
+        for stream in self.head_streams:
+            with self.subTest(stream=stream):
+                config = IntervenableConfig(
+                    model_type=type(self.t5_encoder),
+                    representations=[
+                        RepresentationConfig(0, stream, "h.pos", 1),
+                    ],
+                    intervention_types=VanillaIntervention,
+                )
+                # Constructing the IntervenableModel resolves every
+                # anchor path; if the head split is wrong it raises here.
+                IntervenableModel(config, self.t5_encoder)
+
+    def test_lm_encoder_anchors_resolve(self):
+        """T5ForConditionalGeneration uses the same encoder-rooted anchor
+        paths as the bare T5EncoderModel; verify they still resolve."""
+        for stream in self.nonhead_streams:
+            with self.subTest(stream=stream):
+                config = IntervenableConfig(
+                    model_type=type(self.t5_lm),
+                    representations=[
+                        RepresentationConfig(0, stream, "pos", 1),
+                    ],
+                    intervention_types=VanillaIntervention,
+                )
+                IntervenableModel(config, self.t5_lm)
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(InterventionWithT5TestCase("test_nonhead_streams_encoder"))
+    suite.addTest(InterventionWithT5TestCase("test_head_streams_encoder"))
+    suite.addTest(InterventionWithT5TestCase("test_lm_encoder_anchors_resolve"))
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
## Summary
Adds T5 (`T5Model`, `T5EncoderModel`, `T5ForConditionalGeneration`) to the supported HuggingFace models for #46, following the existing whisper / electra patterns.

- New `pyvene/models/t5/modelings_intervenable_t5.py` with anchor & dimension mappings plus `create_t5*` helpers.
- Registered the three T5 classes in `intervenable_modelcard.py`.
- Smoke tests in `tests/integration_tests/InterventionWithT5TestCase.py` exercise every anchor on a tiny CPU model.

Anchor paths address the **encoder** stack, matching the existing whisper-style encoder-only mapping. Attention dimensions use `num_heads * d_kv` since T5's attention inner_dim can differ from `d_model`.

## Test plan
- [x] `pytest tests/integration_tests/InterventionWithT5TestCase.py` (3 passed, CPU, no checkpoint download)
- [x] `pytest tests/unit_tests/IntervenableConfigUnitTestCase.py` (still passes, no regression)
- [ ] Optional follow-up: add `decoder_block_*` anchors for the decoder stack

Closes the T5 item in #46.